### PR TITLE
Heavily speed up ResizeBetter()

### DIFF
--- a/CharApi/Tools/Tools.cs
+++ b/CharApi/Tools/Tools.cs
@@ -328,71 +328,16 @@ namespace Alexandria.CharacterAPI
 		/// <returns></returns>
 		public static bool ResizeBetter(this Texture2D tex, int width, int height, bool center = false)
         {
-            if (tex.IsReadable())
-            {
-                Color[][] pixels = new Color[Math.Min(tex.width, width)][];
+            if (!tex.IsReadable())
+              return tex.Resize(width, height);
 
-
-                for (int x = 0; x < Math.Min(tex.width, width); x++)
-                {
-                    for (int y = 0; y < Math.Min(tex.height, height); y++)
-                    {
-                        if (pixels[x] == null)
-                        {
-                            pixels[x] = new Color[Math.Min(tex.height, height)];
-                        }
-                        pixels[x][y] = tex.GetPixel(x, y);
-                    }
-                }
-
-                int value = 2;
-                if (center)
-                {
-                    value = 1;
-                }
-                else
-                {
-                    value = 0;
-                }
-
-                bool result = tex.Resize(width, height);
-                for (int x = value; x < tex.width - value; x++)
-                {
-                    for (int y = value; y < tex.height - value; y++)
-                    {
-                        bool isInOrigTex = false;
-                        if (x - value < pixels.Length)
-                        {
-                            if (y - value < pixels[x - value].Length)
-                            {
-                                isInOrigTex = true;
-                                tex.SetPixel(x, y, pixels[x - value][y - value]);
-                            }
-                        }
-                        if (!isInOrigTex)
-                        {
-                            tex.SetPixel(x, y, Color.clear);
-                        }
-                    }
-                }
-
-                for (int x = 0; x < tex.width; x++)
-                {
-                    for (int y = 0; y < tex.height; y++)
-                    {
-
-                        if (tex.GetPixel(x, y) == new Color32(205, 205, 205, 205))
-                        {
-                            tex.SetPixel(x, y, Color.clear);
-                        }
-
-                    }
-                }
-
-                tex.Apply();
-                return result;
-            }
-            return tex.Resize(width, height);
+            int value = center ? 1 : 0;
+            Texture2D tempTex = new Texture2D(width, height);
+            tempTex.SetPixels(value, value, tex.width - 2 * value, tex.height - 2 * value, tex.GetPixels());
+            bool result = tex.Resize(width, height);
+            tex.SetPixels(tempTex.GetPixels());
+            tex.Apply();
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Speeds up the `ResizeBetter()` function by:
- copying pixels from one texture to another all at once as a block, rather than looping through pixels individually
- skipping unnecessarily clearing unused pixels, since the atlas doesn't care about those unused regions anyway and will automatically overwrite them once they do have valid data

This speeds up Atlas resizing from 4.9 seconds during startup to 1.1 seconds on my machine. Depending on how many mods are loaded and how many of them are adding new UI sprites, this could speed load times up dramatically.

