### PR TITLE
Various cAPI fixes

### DIFF
--- a/Module.cs
+++ b/Module.cs
@@ -30,7 +30,7 @@ namespace Alexandria
         public const string GUID = "alexandria.etgmod.alexandria";
         public const string NAME = "Alexandria";
 
-        public const string VERSION = "0.4.0";
+        public const string VERSION = "0.4.4";
 
 
         public void Start()

--- a/cAPI/Hat.cs
+++ b/cAPI/Hat.cs
@@ -324,7 +324,7 @@ namespace Alexandria.cAPI
                 animationFrameSpecificOffset += flipped ? frameOffset.flipOffset : frameOffset.offset;
 
             // combine everything and return
-            return baseOffset + animationFrameSpecificOffset + (flipped ? hatFlipOffset : hatOffset) + playerSpecificOffset;
+            return baseOffset + animationFrameSpecificOffset + ((flipped && flipHorizontalWithPlayer) ? hatFlipOffset : hatOffset) + playerSpecificOffset;
         }
 
         internal void StickHatToPlayer(PlayerController player)

--- a/cAPI/Hat.cs
+++ b/cAPI/Hat.cs
@@ -302,13 +302,19 @@ namespace Alexandria.cAPI
 
             // get the base offset for every character
             float effectiveX = player.SpriteBottomCenter.x;
-            if (flipped) // if the sprite is flipped, we need to account for whether the player sprite and hat sprite are even / odd pixels and adjust the offset accordingly
+            // due to weird rounding issues, we need to account for whether the player sprite and hat sprite are even / odd pixels and adjust the offset accordingly
+            int playerWidth = Mathf.RoundToInt(16f * cachedDef.untrimmedBoundsDataExtents.x); // use untrimmed bounds to avoid missing pixels on alt skins
+            if (flipped)
             {
-                int playerWidth = Mathf.RoundToInt(16f * cachedDef.untrimmedBoundsDataExtents.x); // use untrimmed bounds to avoid missing pixels on alt skins
                 if (playerWidth % 2 == 0) // if our player sprite is an even number of pixels, we need to quantize our center point
                     effectiveX = effectiveX.Quantize(0.0625f, (hatWidth % 2 == 0) ? VectorConversions.Ceil : VectorConversions.Floor);
                 if ((hatWidth + playerWidth) % 2 == 1) // if the sum of our player sprite width and hat sprite width is odd, we need to adjust by another half pixel
                     effectiveX += 1f/32f;
+            }
+            else
+            {
+                if ((hatWidth + playerWidth) % 2 == 1) // if the sum of our player sprite width and hat sprite width is odd, we need to adjust by another half pixel
+                    effectiveX -= 1f/32f;
             }
             Vector2 baseOffset = new(effectiveX, player.sprite.transform.position.y);
 

--- a/cAPI/HatRoom.cs
+++ b/cAPI/HatRoom.cs
@@ -52,9 +52,9 @@ namespace Alexandria.cAPI
         }
     }
 
-    /// <summary>Marks the hat room in need of regeneration every time the Breach is unloaded</summary>
-    [HarmonyPatch(typeof(Foyer), nameof(Foyer.OnDepartedFoyer))]
-    private class OnDepartedFoyerPatch
+    /// <summary>Marks the hat room in need of regeneration every time the Breach is reloaded</summary>
+    [HarmonyPatch(typeof(Foyer), nameof(Foyer.Start))]
+    private class OnFoyerStartPatch
     {
         static void Postfix(Foyer __instance)
         {


### PR DESCRIPTION
- Bump version to 0.4.4 to match Thunderstore
- Fixed hat offsets not updating when player swaps costumes in the Breach
- Fixed hat room not generating if continuing a saved game then returning to the Breach
- Fixed non-flipping hat sprites still using flipped hat offsets when player is flipped
- Fixed hat outlines being off by a pixel when facing right on certain GPUs (rounding pog)