### PR TITLE
Fixed Beam APIs, reverted accidental removal of public method, and cleaned up several parts of the code base

### DIFF
--- a/Alexandria.csproj
+++ b/Alexandria.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Misc\EnumUtility.cs" />
     <Compile Include="Misc\DebugUtility.cs" />
     <Compile Include="Misc\LootUtility.cs" />
+    <Compile Include="Misc\SharedExtensions.cs" />
     <Compile Include="Misc\MathAndLogicHelper.cs" />
     <Compile Include="Misc\ReflectionUtility.cs" />
     <Compile Include="Module.cs" />

--- a/Assetbundle/BeamBuilders.cs
+++ b/Assetbundle/BeamBuilders.cs
@@ -156,56 +156,7 @@ namespace Alexandria.Assetbundle
 
         public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
-            if (!scale.HasValue)
-            {
-                scale = new Vector2?(def.position3);
-            }
-            if (fixesScale)
-            {
-                Vector2 fixedScale = scale.Value - def.position0.XY();
-                scale = new Vector2?(fixedScale);
-            }
-            float xOffset = 0;
-            if (anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.UpperCenter)
-            {
-                xOffset = -(scale.Value.x / 2f);
-            }
-            else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
-            {
-                xOffset = -scale.Value.x;
-            }
-            float yOffset = 0;
-            if (anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.MiddleLeft)
-            {
-                yOffset = -(scale.Value.y / 2f);
-            }
-            else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
-            {
-                yOffset = -scale.Value.y;
-            }
-            def.MakeOffset(new Vector2(xOffset, yOffset), false);
-            if (changesCollider && def.colliderVertices != null && def.colliderVertices.Length > 0)
-            {
-                float colliderXOffset = 0;
-                if (anchor == tk2dBaseSprite.Anchor.LowerLeft || anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.UpperLeft)
-                {
-                    colliderXOffset = (scale.Value.x / 2f);
-                }
-                else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
-                {
-                    colliderXOffset = -(scale.Value.x / 2f);
-                }
-                float colliderYOffset = 0;
-                if (anchor == tk2dBaseSprite.Anchor.LowerLeft || anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.LowerRight)
-                {
-                    colliderYOffset = (scale.Value.y / 2f);
-                }
-                else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
-                {
-                    colliderYOffset = -(scale.Value.y / 2f);
-                }
-                def.colliderVertices[0] += new Vector3(colliderXOffset, colliderYOffset, 0);
-            }
+            SharedExtensions.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
         }
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {

--- a/Assetbundle/BeamBuilders.cs
+++ b/Assetbundle/BeamBuilders.cs
@@ -158,6 +158,7 @@ namespace Alexandria.Assetbundle
         {
             Shared.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
         }
+
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
             Shared.MakeOffset(def, offset, changesCollider);
@@ -165,36 +166,10 @@ namespace Alexandria.Assetbundle
 
         private static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, tk2dSpriteCollectionData data, string animationName, Vector2? colliderDimensions = null, Vector2? colliderOffsets = null, Vector3[] overrideVertices = null, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Once)
         {
-
-            foreach (var path in beamAnimation.GetClipByName(animationName).frames)
-            {
-                tk2dSpriteDefinition frameDef = data.spriteDefinitions[path.spriteId];
-                frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft);
-                if (overrideVertices != null)
-                {
-                    frameDef.colliderVertices = overrideVertices;
-                }
-                else
-                {
-                    if (colliderDimensions == null || colliderOffsets == null)
-                    {
-                        ETGModConsole.Log("<size=100><color=#ff0000ff>BEAM ERROR: colliderDimensions or colliderOffsets was null with no override vertices!</color></size>", false);
-                    }
-                    else
-                    {
-                        Vector2 actualDimensions = (Vector2)colliderDimensions;
-                        Vector2 actualOffsets = (Vector2)colliderDimensions;
-                        frameDef.colliderVertices = new Vector3[]{
-                            new Vector3(actualOffsets.x / 16, actualOffsets.y / 16, 0f),
-                            new Vector3(actualDimensions.x / 16, actualDimensions.y / 16, 0f)
-                        };
-                    }
-                }
-            }
+            Shared.SetupBeamPart(beamAnimation, data, animationName, colliderDimensions, colliderOffsets, overrideVertices, wrapMode, anchor: tk2dBaseSprite.Anchor.MiddleLeft);
         }
-
-
     }
+
     internal class EmmisiveBeams : MonoBehaviour
     {
         public EmmisiveBeams()

--- a/Assetbundle/BeamBuilders.cs
+++ b/Assetbundle/BeamBuilders.cs
@@ -4,44 +4,33 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 using Alexandria.Misc;
+using Alexandria.ItemAPI;
 
 namespace Alexandria.Assetbundle
 {
     public static class BeamBuilders
     {
         public static BasicBeamController GenerateBeamPrefabBundle(this Projectile projectile, string defaultSpriteName, tk2dSpriteCollectionData data, tk2dSpriteAnimation animation, string IdleAnimationName, Vector2 colliderDimensions, Vector2 colliderOffsets, string impactVFXAnimationName = null, Vector2? impactVFXColliderDimensions = null, Vector2? impactVFXColliderOffsets = null, string endAnimation = null, Vector2? endColliderDimensions = null, Vector2? endColliderOffsets = null, string muzzleAnimationName = null, Vector2? muzzleColliderDimensions = null, Vector2? muzzleColliderOffsets = null, bool glows = false,
-        bool canTelegraph = false, string beamTelegraphIdleAnimationName = null, string beamStartTelegraphAnimationName = null, string beamEndTelegraphAnimationName = null, float telegraphTime = 1,
-        bool canDissipate = false, string beamDissipateAnimationName = null, string beamStartDissipateAnimationName = null, string beamEndDissipateAnimationName = null, float dissipateTime = 1)
-
+            bool canTelegraph = false, string beamTelegraphIdleAnimationName = null, string beamStartTelegraphAnimationName = null, string beamEndTelegraphAnimationName = null, float telegraphTime = 1,
+            bool canDissipate = false, string beamDissipateAnimationName = null, string beamStartDissipateAnimationName = null, string beamEndDissipateAnimationName = null, float dissipateTime = 1)
         {
             try
             {
-                projectile.specRigidbody.CollideWithOthers = false;
-
-
-                float convertedColliderX = colliderDimensions.x / 16f;
-                float convertedColliderY = colliderDimensions.y / 16f;
-                float convertedOffsetX = colliderOffsets.x / 16f;
-                float convertedOffsetY = colliderOffsets.y / 16f;
-
+                if (projectile.specRigidbody)
+                    projectile.specRigidbody.CollideWithOthers = false;
 
                 tk2dTiledSprite tiledSprite = projectile.gameObject.GetOrAddComponent<tk2dTiledSprite>();
 
                 tiledSprite.Collection = data;
                 tiledSprite.SetSprite(data, data.GetSpriteIdByName(defaultSpriteName));
                 tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
-                def.colliderVertices = new Vector3[]{
-                    new Vector3(convertedOffsetX, convertedOffsetY, 0f),
-                    new Vector3(convertedColliderX, convertedColliderY, 0f)
-                };
+                def.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets, 0.0625f * colliderDimensions };
 
-                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft);
+                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft); //NOTE: this seems right, but double check later
 
-                //tiledSprite.anchor = tk2dBaseSprite.Anchor.MiddleCenter;
                 tk2dSpriteAnimator animator = projectile.gameObject.GetOrAddComponent<tk2dSpriteAnimator>();
                 animator._startingSpriteCollection = data;
                 animator.Library = animation;
-                animator.library = animation;
                 animator.playAutomatically = true;
                 animator.defaultClipId = animation.GetClipIdByName(IdleAnimationName);
 
@@ -52,9 +41,7 @@ namespace Alexandria.Assetbundle
                 BasicBeamController beamController = projectile.gameObject.GetOrAddComponent<BasicBeamController>();
                 beamController.sprite = tiledSprite;
                 beamController.spriteAnimator = animator;
-                beamController.spriteAnimator._startingSpriteCollection = data;
                 beamController.m_beamSprite = tiledSprite;
-
 
                 //---------------- Sets up the animation for the main part of the beam
                 beamController.beamAnimation = IdleAnimationName;
@@ -91,60 +78,52 @@ namespace Alexandria.Assetbundle
                     beamController.beamStartAnimation = IdleAnimationName;
                 }
 
-
-
-                if (canTelegraph == true)
+                if (canTelegraph)
                 {
                     beamController.usesTelegraph = true;
                     beamController.telegraphAnimations = new BasicBeamController.TelegraphAnims();
                     if (beamStartTelegraphAnimationName != null)
                     {
-                        SetupBeamPart(animation, data, beamStartTelegraphAnimationName, new Vector2(0, 0), new Vector2(0, 0));
+                        SetupBeamPart(animation, data, beamStartTelegraphAnimationName, Vector2.zero, Vector2.zero);
                         beamController.telegraphAnimations.beamStartAnimation = beamStartTelegraphAnimationName;
                     }
                     if (beamTelegraphIdleAnimationName != null)
                     {
-                        SetupBeamPart(animation, data, beamTelegraphIdleAnimationName, new Vector2(0, 0), new Vector2(0, 0));
+                        SetupBeamPart(animation, data, beamTelegraphIdleAnimationName, Vector2.zero, Vector2.zero);
                         beamController.telegraphAnimations.beamAnimation = beamTelegraphIdleAnimationName;
                     }
                     if (beamEndTelegraphAnimationName != null)
                     {
-                        SetupBeamPart(animation, data, beamEndTelegraphAnimationName, new Vector2(0, 0), new Vector2(0, 0));
+                        SetupBeamPart(animation, data, beamEndTelegraphAnimationName, Vector2.zero, Vector2.zero);
                         beamController.telegraphAnimations.beamEndAnimation = beamEndTelegraphAnimationName;
                     }
                     beamController.telegraphTime = telegraphTime;
                 }
 
-
-                if (canDissipate == true)
+                if (canDissipate)
                 {
                     beamController.endType = BasicBeamController.BeamEndType.Dissipate;
                     beamController.dissipateAnimations = new BasicBeamController.TelegraphAnims();
                     if (beamStartDissipateAnimationName != null)
                     {
-                        SetupBeamPart(animation, data, beamStartDissipateAnimationName, new Vector2(0, 0), new Vector2(0, 0));
+                        SetupBeamPart(animation, data, beamStartDissipateAnimationName, Vector2.zero, Vector2.zero);
                         beamController.dissipateAnimations.beamStartAnimation = beamStartDissipateAnimationName;
                     }
                     if (beamDissipateAnimationName != null)
                     {
-                        SetupBeamPart(animation, data, beamDissipateAnimationName, new Vector2(0, 0), new Vector2(0, 0));
+                        SetupBeamPart(animation, data, beamDissipateAnimationName, Vector2.zero, Vector2.zero);
                         beamController.dissipateAnimations.beamAnimation = beamDissipateAnimationName;
                     }
                     if (beamEndDissipateAnimationName != null)
                     {
-                        SetupBeamPart(animation, data, beamEndDissipateAnimationName, new Vector2(0, 0), new Vector2(0, 0));
+                        SetupBeamPart(animation, data, beamEndDissipateAnimationName, Vector2.zero, Vector2.zero);
                         beamController.dissipateAnimations.beamEndAnimation = beamEndDissipateAnimationName;
                     }
                     beamController.dissipateTime = dissipateTime;
                 }
 
-
                 if (glows)
-                {
-                    EmmisiveBeams emission = projectile.gameObject.GetOrAddComponent<EmmisiveBeams>();
-                    //emission
-
-                }
+                    projectile.gameObject.GetOrAddComponent<EmmisiveBeams>();
                 return beamController;
             }
             catch (Exception e)
@@ -168,76 +147,5 @@ namespace Alexandria.Assetbundle
         {
             Shared.SetupBeamPart(beamAnimation, data, animationName, colliderDimensions, colliderOffsets, overrideVertices, wrapMode, anchor: tk2dBaseSprite.Anchor.MiddleLeft);
         }
-    }
-
-    internal class EmmisiveBeams : MonoBehaviour
-    {
-        public EmmisiveBeams()
-        {
-            this.EmissivePower = 100;
-            this.EmissiveColorPower = 1.55f;
-        }
-        public void Start()
-        {
-            Shader glowshader = ShaderCache.Acquire("Brave/LitTk2dCustomFalloffTiltedCutoutEmissive");
-
-            foreach (Transform transform in base.transform)
-            {
-                if (TransformList.Contains(transform.name))
-                {
-                    tk2dSprite sproot = transform.GetComponent<tk2dSprite>();
-                    if (sproot != null)
-                    {
-                        sproot.usesOverrideMaterial = true;
-                        sproot.renderer.material.shader = glowshader;
-                        sproot.renderer.material.EnableKeyword("BRIGHTNESS_CLAMP_ON");
-                        sproot.renderer.material.SetFloat("_EmissivePower", EmissivePower);
-                        sproot.renderer.material.SetFloat("_EmissiveColorPower", EmissiveColorPower);
-                    }
-                }
-            }
-            this.beamcont = base.GetComponent<BasicBeamController>();
-            BasicBeamController beam = this.beamcont;
-            beam.sprite.usesOverrideMaterial = true;
-            BasicBeamController component = beam.gameObject.GetComponent<BasicBeamController>();
-            bool flag = component != null;
-            bool flag2 = flag;
-            if (flag2)
-            {
-                component.sprite.renderer.material.shader = glowshader;
-                component.sprite.renderer.material.EnableKeyword("BRIGHTNESS_CLAMP_ON");
-                component.sprite.renderer.material.SetFloat("_EmissivePower", EmissivePower);
-                component.sprite.renderer.material.SetFloat("_EmissiveColorPower", EmissiveColorPower);
-            }
-        }
-
-
-        private List<string> TransformList = new List<string>()
-        {
-            "Sprite",
-            "beam impact vfx 2",
-            "beam impact vfx",
-        };
-
-
-        public void Update()
-        {
-            Shader glowshader = ShaderCache.Acquire("Brave/LitTk2dCustomFalloffTiltedCutoutEmissive");
-            Transform trna = base.transform.Find("beam pierce impact vfx");
-            if (trna != null)
-            {
-                tk2dSprite sproot = trna.GetComponent<tk2dSprite>();
-                if (sproot != null)
-                {
-                    sproot.renderer.material.shader = glowshader;
-                    sproot.renderer.material.EnableKeyword("BRIGHTNESS_CLAMP_ON");
-                    sproot.renderer.material.SetFloat("_EmissivePower", EmissivePower);
-                    sproot.renderer.material.SetFloat("_EmissiveColorPower", EmissiveColorPower);
-                }
-            }
-        }
-        private BasicBeamController beamcont;
-        public float EmissivePower;
-        public float EmissiveColorPower;
     }
 }

--- a/Assetbundle/BeamBuilders.cs
+++ b/Assetbundle/BeamBuilders.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using Alexandria.Misc;
 
 namespace Alexandria.Assetbundle
 {
@@ -208,20 +209,7 @@ namespace Alexandria.Assetbundle
         }
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            float xOffset = offset.x;
-            float yOffset = offset.y;
-            def.position0 += new Vector3(xOffset, yOffset, 0);
-            def.position1 += new Vector3(xOffset, yOffset, 0);
-            def.position2 += new Vector3(xOffset, yOffset, 0);
-            def.position3 += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            if (def.colliderVertices != null && def.colliderVertices.Length > 0 && changesCollider)
-            {
-                def.colliderVertices[0] += new Vector3(xOffset, yOffset, 0);
-            }
+            SharedExtensions.MakeOffset(def, offset, changesCollider);
         }
 
         private static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, tk2dSpriteCollectionData data, string animationName, Vector2? colliderDimensions = null, Vector2? colliderOffsets = null, Vector3[] overrideVertices = null, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Once)

--- a/Assetbundle/BeamBuilders.cs
+++ b/Assetbundle/BeamBuilders.cs
@@ -10,130 +10,85 @@ namespace Alexandria.Assetbundle
 {
     public static class BeamBuilders
     {
-        public static BasicBeamController GenerateBeamPrefabBundle(this Projectile projectile, string defaultSpriteName, tk2dSpriteCollectionData data, tk2dSpriteAnimation animation, string IdleAnimationName, Vector2 colliderDimensions, Vector2 colliderOffsets, string impactVFXAnimationName = null, Vector2? impactVFXColliderDimensions = null, Vector2? impactVFXColliderOffsets = null, string endAnimation = null, Vector2? endColliderDimensions = null, Vector2? endColliderOffsets = null, string muzzleAnimationName = null, Vector2? muzzleColliderDimensions = null, Vector2? muzzleColliderOffsets = null, bool glows = false,
-            bool canTelegraph = false, string beamTelegraphIdleAnimationName = null, string beamStartTelegraphAnimationName = null, string beamEndTelegraphAnimationName = null, float telegraphTime = 1,
-            bool canDissipate = false, string beamDissipateAnimationName = null, string beamStartDissipateAnimationName = null, string beamEndDissipateAnimationName = null, float dissipateTime = 1)
+        public static BasicBeamController GenerateBeamPrefabBundle(this Projectile projectile, string defaultSpriteName, tk2dSpriteCollectionData data,
+            tk2dSpriteAnimation animation, string IdleAnimationName, Vector2 colliderDimensions, Vector2 colliderOffsets, string impactVFXAnimationName = null,
+            Vector2? impactVFXColliderDimensions = null, Vector2? impactVFXColliderOffsets = null, string endAnimation = null, Vector2? endColliderDimensions = null,
+            Vector2? endColliderOffsets = null, string muzzleAnimationName = null, Vector2? muzzleColliderDimensions = null, Vector2? muzzleColliderOffsets = null,
+            bool glows = false, bool canTelegraph = false, string beamTelegraphIdleAnimationName = null, string beamStartTelegraphAnimationName = null,
+            string beamEndTelegraphAnimationName = null, float telegraphTime = 1, bool canDissipate = false, string beamDissipateAnimationName = null,
+            string beamStartDissipateAnimationName = null, string beamEndDissipateAnimationName = null, float dissipateTime = 1)
         {
-            try
-            {
-                if (projectile.specRigidbody)
-                    projectile.specRigidbody.CollideWithOthers = false;
-
-                tk2dTiledSprite tiledSprite = projectile.gameObject.GetOrAddComponent<tk2dTiledSprite>();
-
-                tiledSprite.Collection = data;
-                tiledSprite.SetSprite(data, data.GetSpriteIdByName(defaultSpriteName));
-                tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
-                def.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets, 0.0625f * colliderDimensions };
-
-                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft); //NOTE: this seems right, but double check later
-
-                tk2dSpriteAnimator animator = projectile.gameObject.GetOrAddComponent<tk2dSpriteAnimator>();
-                animator._startingSpriteCollection = data;
-                animator.Library = animation;
-                animator.playAutomatically = true;
-                animator.defaultClipId = animation.GetClipIdByName(IdleAnimationName);
-
-                UnityEngine.Object.Destroy(projectile.GetComponentInChildren<tk2dSprite>());
-                projectile.sprite = tiledSprite;
-                projectile.sprite.Collection = data;
-
-                BasicBeamController beamController = projectile.gameObject.GetOrAddComponent<BasicBeamController>();
-                beamController.sprite = tiledSprite;
-                beamController.spriteAnimator = animator;
-                beamController.m_beamSprite = tiledSprite;
-
-                //---------------- Sets up the animation for the main part of the beam
-                beamController.beamAnimation = IdleAnimationName;
-
-                //------------- Sets up the animation for the part of the beam that touches the wall
-
-                if (endAnimation != null && endColliderDimensions != null && endColliderOffsets != null)
-                {
-                    SetupBeamPart(animation, data, endAnimation, (Vector2)endColliderDimensions, (Vector2)endColliderOffsets);
-                    beamController.beamEndAnimation = endAnimation;
-                }
-                else
-                {
-                    SetupBeamPart(animation, data, IdleAnimationName, null, null, def.colliderVertices);
-                    beamController.beamEndAnimation = IdleAnimationName;
-                }
-
-                //---------------Sets up the animaton for the VFX that plays over top of the end of the beam where it hits stuff
-                if (impactVFXAnimationName != null && impactVFXColliderDimensions != null && impactVFXColliderOffsets != null)
-                {
-                    SetupBeamPart(animation, data, impactVFXAnimationName, (Vector2)impactVFXColliderDimensions, (Vector2)impactVFXColliderOffsets);
-                    beamController.impactAnimation = impactVFXAnimationName;
-                }
-
-                //--------------Sets up the animation for the very start of the beam
-                if (muzzleAnimationName != null && muzzleColliderDimensions != null && muzzleColliderOffsets != null)
-                {
-                    SetupBeamPart(animation, data, muzzleAnimationName, (Vector2)muzzleColliderDimensions, (Vector2)muzzleColliderOffsets);
-                    beamController.beamStartAnimation = muzzleAnimationName;
-                }
-                else
-                {
-                    SetupBeamPart(animation, data, IdleAnimationName, null, null, def.colliderVertices);
-                    beamController.beamStartAnimation = IdleAnimationName;
-                }
-
-                if (canTelegraph)
-                {
-                    beamController.usesTelegraph = true;
-                    beamController.telegraphAnimations = new BasicBeamController.TelegraphAnims();
-                    if (beamStartTelegraphAnimationName != null)
-                    {
-                        SetupBeamPart(animation, data, beamStartTelegraphAnimationName, Vector2.zero, Vector2.zero);
-                        beamController.telegraphAnimations.beamStartAnimation = beamStartTelegraphAnimationName;
-                    }
-                    if (beamTelegraphIdleAnimationName != null)
-                    {
-                        SetupBeamPart(animation, data, beamTelegraphIdleAnimationName, Vector2.zero, Vector2.zero);
-                        beamController.telegraphAnimations.beamAnimation = beamTelegraphIdleAnimationName;
-                    }
-                    if (beamEndTelegraphAnimationName != null)
-                    {
-                        SetupBeamPart(animation, data, beamEndTelegraphAnimationName, Vector2.zero, Vector2.zero);
-                        beamController.telegraphAnimations.beamEndAnimation = beamEndTelegraphAnimationName;
-                    }
-                    beamController.telegraphTime = telegraphTime;
-                }
-
-                if (canDissipate)
-                {
-                    beamController.endType = BasicBeamController.BeamEndType.Dissipate;
-                    beamController.dissipateAnimations = new BasicBeamController.TelegraphAnims();
-                    if (beamStartDissipateAnimationName != null)
-                    {
-                        SetupBeamPart(animation, data, beamStartDissipateAnimationName, Vector2.zero, Vector2.zero);
-                        beamController.dissipateAnimations.beamStartAnimation = beamStartDissipateAnimationName;
-                    }
-                    if (beamDissipateAnimationName != null)
-                    {
-                        SetupBeamPart(animation, data, beamDissipateAnimationName, Vector2.zero, Vector2.zero);
-                        beamController.dissipateAnimations.beamAnimation = beamDissipateAnimationName;
-                    }
-                    if (beamEndDissipateAnimationName != null)
-                    {
-                        SetupBeamPart(animation, data, beamEndDissipateAnimationName, Vector2.zero, Vector2.zero);
-                        beamController.dissipateAnimations.beamEndAnimation = beamEndDissipateAnimationName;
-                    }
-                    beamController.dissipateTime = dissipateTime;
-                }
-
-                if (glows)
-                    projectile.gameObject.GetOrAddComponent<EmmisiveBeams>();
-                return beamController;
-            }
-            catch (Exception e)
-            {
-                ETGModConsole.Log(e.ToString());
-                return null;
-            }
+            return projectile.GenerateBeamPrefabBundleInternal(
+                defaultSpriteName: defaultSpriteName,
+                data: data,
+                animation: animation,
+                IdleAnimationName: IdleAnimationName,
+                colliderDimensions: colliderDimensions,
+                colliderOffsets: colliderOffsets,
+                impactVFXAnimationName: impactVFXAnimationName,
+                impactVFXColliderDimensions: impactVFXColliderDimensions,
+                impactVFXColliderOffsets: impactVFXColliderOffsets,
+                endAnimation: endAnimation,
+                endColliderDimensions: endColliderDimensions,
+                endColliderOffsets: endColliderOffsets,
+                muzzleAnimationName: muzzleAnimationName,
+                muzzleColliderDimensions: muzzleColliderDimensions,
+                muzzleColliderOffsets: muzzleColliderOffsets,
+                glows: glows,
+                canTelegraph: canTelegraph,
+                beamTelegraphIdleAnimationName: beamTelegraphIdleAnimationName,
+                beamStartTelegraphAnimationName: beamStartTelegraphAnimationName,
+                beamEndTelegraphAnimationName: beamEndTelegraphAnimationName,
+                telegraphTime: telegraphTime,
+                canDissipate: canDissipate,
+                beamDissipateAnimationName: beamDissipateAnimationName,
+                beamStartDissipateAnimationName: beamStartDissipateAnimationName,
+                beamEndDissipateAnimationName: beamEndDissipateAnimationName,
+                dissipateTime: dissipateTime,
+                constructOffsets: true);
         }
 
-        public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
+        /// <summary>Version of GenerateBeamPrefabBundle to use if anchors have already been set up in the asset bundle</summary>
+        public static BasicBeamController GenerateAnchoredBeamPrefabBundle(this Projectile projectile, string defaultSpriteName, tk2dSpriteCollectionData data,
+            tk2dSpriteAnimation animation, string IdleAnimationName, Vector2 colliderDimensions, Vector2 colliderOffsets, string impactVFXAnimationName = null,
+            Vector2? impactVFXColliderDimensions = null, Vector2? impactVFXColliderOffsets = null, string endAnimation = null, Vector2? endColliderDimensions = null,
+            Vector2? endColliderOffsets = null, string muzzleAnimationName = null, Vector2? muzzleColliderDimensions = null, Vector2? muzzleColliderOffsets = null,
+            bool glows = false, bool canTelegraph = false, string beamTelegraphIdleAnimationName = null, string beamStartTelegraphAnimationName = null,
+            string beamEndTelegraphAnimationName = null, float telegraphTime = 1, bool canDissipate = false, string beamDissipateAnimationName = null,
+            string beamStartDissipateAnimationName = null, string beamEndDissipateAnimationName = null, float dissipateTime = 1)
+        {
+            return projectile.GenerateBeamPrefabBundleInternal(
+                defaultSpriteName: defaultSpriteName,
+                data: data,
+                animation: animation,
+                IdleAnimationName: IdleAnimationName,
+                colliderDimensions: colliderDimensions,
+                colliderOffsets: colliderOffsets,
+                impactVFXAnimationName: impactVFXAnimationName,
+                impactVFXColliderDimensions: impactVFXColliderDimensions,
+                impactVFXColliderOffsets: impactVFXColliderOffsets,
+                endAnimation: endAnimation,
+                endColliderDimensions: endColliderDimensions,
+                endColliderOffsets: endColliderOffsets,
+                muzzleAnimationName: muzzleAnimationName,
+                muzzleColliderDimensions: muzzleColliderDimensions,
+                muzzleColliderOffsets: muzzleColliderOffsets,
+                glows: glows,
+                canTelegraph: canTelegraph,
+                beamTelegraphIdleAnimationName: beamTelegraphIdleAnimationName,
+                beamStartTelegraphAnimationName: beamStartTelegraphAnimationName,
+                beamEndTelegraphAnimationName: beamEndTelegraphAnimationName,
+                telegraphTime: telegraphTime,
+                canDissipate: canDissipate,
+                beamDissipateAnimationName: beamDissipateAnimationName,
+                beamStartDissipateAnimationName: beamStartDissipateAnimationName,
+                beamEndDissipateAnimationName: beamEndDissipateAnimationName,
+                dissipateTime: dissipateTime,
+                constructOffsets: false);
+        }
+
+        public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false,
+            bool changesCollider = true)
         {
             Shared.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
         }
@@ -141,11 +96,6 @@ namespace Alexandria.Assetbundle
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
             Shared.MakeOffset(def, offset, changesCollider);
-        }
-
-        private static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, tk2dSpriteCollectionData data, string animationName, Vector2? colliderDimensions = null, Vector2? colliderOffsets = null, Vector3[] overrideVertices = null, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Once)
-        {
-            Shared.SetupBeamPart(beamAnimation, data, animationName, colliderDimensions, colliderOffsets, overrideVertices, wrapMode, anchor: tk2dBaseSprite.Anchor.MiddleLeft);
         }
     }
 }

--- a/Assetbundle/BeamBuilders.cs
+++ b/Assetbundle/BeamBuilders.cs
@@ -156,11 +156,11 @@ namespace Alexandria.Assetbundle
 
         public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
-            SharedExtensions.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
+            Shared.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
         }
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            SharedExtensions.MakeOffset(def, offset, changesCollider);
+            Shared.MakeOffset(def, offset, changesCollider);
         }
 
         private static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, tk2dSpriteCollectionData data, string animationName, Vector2? colliderDimensions = null, Vector2? colliderOffsets = null, Vector3[] overrideVertices = null, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Once)

--- a/Assetbundle/ProjectileBuilders.cs
+++ b/Assetbundle/ProjectileBuilders.cs
@@ -25,7 +25,7 @@ namespace Alexandria.Assetbundle
                 tk2dSpriteDefinition def = SetupDefinitionForProjectileSprite(name, proj.GetAnySprite().spriteId, data, pixelWidth, pixelHeight, lightened,
                     overrideColliderPixelWidth, overrideColliderPixelHeight, overrideColliderOffsetX, overrideColliderOffsetY, overrideProjectileToCopyFrom);
 
-                def.ConstructOffsetsFromAnchor(anchor, def.position3, fixesScale, anchorChangesCollider);
+                Shared.ConstructOffsetsFromAnchor(def, anchor, def.position3, fixesScale, anchorChangesCollider);
                 proj.GetAnySprite().scale = Vector3.one;
                 proj.transform.localScale = Vector3.one;
                 proj.GetAnySprite().transform.localScale = Vector3.one;
@@ -42,38 +42,8 @@ namespace Alexandria.Assetbundle
 
         private static tk2dSpriteDefinition SetupDefinitionForProjectileSprite(string name, int id, tk2dSpriteCollectionData data, int pixelWidth, int pixelHeight, bool lightened = true, int? overrideColliderPixelWidth = null, int? overrideColliderPixelHeight = null, int? overrideColliderOffsetX = null, int? overrideColliderOffsetY = null, Projectile overrideProjectileToCopyFrom = null)
         {
-            overrideColliderPixelWidth ??= pixelWidth;
-            overrideColliderPixelHeight ??= pixelHeight;
-            overrideColliderOffsetX ??= 0;
-            overrideColliderOffsetY ??= 0;
-
-            float trueWidth = 0.0625f * pixelWidth;
-            float trueHeight = 0.0625f * pixelHeight;
-            float colliderWidth = 0.0625f * overrideColliderPixelWidth.Value;
-            float colliderHeight = 0.0625f * overrideColliderPixelHeight.Value;
-            float colliderOffsetX = 0.0625f * overrideColliderOffsetX.Value;
-            float colliderOffsetY = 0.0625f * overrideColliderOffsetY.Value;
-            tk2dSpriteDefinition def = ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[(overrideProjectileToCopyFrom ??
-                    (PickupObjectDatabase.GetById(lightened ? 47 : 12) as Gun).DefaultModule.projectiles[0]).GetAnySprite().spriteId].CopyDefinitionFrom();
-            def.boundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
-            def.boundsDataExtents = new Vector3(trueWidth, trueHeight, 0f);
-            def.untrimmedBoundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
-            def.untrimmedBoundsDataExtents = new Vector3(trueWidth, trueHeight, 0f);
-            def.texelSize = new Vector2(1 / 16f, 1 / 16f);
-            def.position0 = new Vector3(0f, 0f, 0f);
-            def.position1 = new Vector3(0f + trueWidth, 0f, 0f);
-            def.position2 = new Vector3(0f, 0f + trueHeight, 0f);
-            def.position3 = new Vector3(0f + trueWidth, 0f + trueHeight, 0f);
-
-            def.materialInst.mainTexture = data.spriteDefinitions[id].materialInst.mainTexture;
-            def.uvs = data.spriteDefinitions[id].uvs.ToArray();
-
-            def.colliderVertices = new Vector3[2];
-            def.colliderVertices[0] = new Vector3(colliderOffsetX, colliderOffsetY, 0f);
-            def.colliderVertices[1] = new Vector3(colliderWidth / 2, colliderHeight / 2);
-            def.name = name;
-            data.spriteDefinitions[id] = def;
-            return def;
+            return Shared.SetupDefinitionForProjectileSprite(name, id, data, pixelWidth, pixelHeight, lightened, overrideColliderPixelWidth,
+                overrideColliderPixelHeight, overrideColliderOffsetX, overrideColliderOffsetY, overrideProjectileToCopyFrom);
         }
 
         public static void AnimateProjectileBundle(this Projectile proj, string defaultClipName, tk2dSpriteCollectionData data, tk2dSpriteAnimation animation, string animationName, List<IntVector2> pixelSizes, List<bool> lighteneds, List<tk2dBaseSprite.Anchor> anchors, List<bool> anchorsChangeColliders, List<bool> fixesScales, List<Vector3?> manualOffsets, List<IntVector2?> overrideColliderPixelSizes, List<IntVector2?> overrideColliderOffsets, List<Projectile> overrideProjectilesToCopyFrom)
@@ -95,7 +65,7 @@ namespace Alexandria.Assetbundle
                 tk2dSpriteDefinition def = SetupDefinitionForProjectileSprite(animationName, frames[i].spriteId, data, pixelSizes[i].x, pixelSizes[i].y, lighteneds[i],
                     overrideColliderPixelSizes[i]?.x, overrideColliderPixelSizes[i]?.y, overrideColliderOffsets[i]?.x, overrideColliderOffsets[i]?.y,
                     overrideProjectilesToCopyFrom[i]);
-                def.ConstructOffsetsFromAnchor(anchors[i], def.position3, fixesScales[i], anchorsChangeColliders[i]);
+                Shared.ConstructOffsetsFromAnchor(def, anchors[i], def.position3, fixesScales[i], anchorsChangeColliders[i]);
                 if (manualOffsets[i] is Vector3 manualOffset)
                 {
                     def.position0 += manualOffset;
@@ -120,7 +90,7 @@ namespace Alexandria.Assetbundle
                 tiledSprite.SetSprite(tk2DSpriteCollectionData, tk2DSpriteCollectionData.GetSpriteIdByName(spriteName));
                 tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
                 def.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets, 0.0625f * colliderDimensions };
-                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft); //NOTE: this doesn't seem right, but maybe it is?
+                Shared.ConstructOffsetsFromAnchor(def, tk2dBaseSprite.Anchor.LowerLeft); //NOTE: this doesn't seem right, but maybe it is?
                 tk2dSpriteAnimator animator = newTrailObject.GetOrAddComponent<tk2dSpriteAnimator>();
                 animator.playAutomatically = true;
                 animator.defaultClipId = animationLibrary.GetClipIdByName(defaultAnimation);

--- a/Assetbundle/ProjectileBuilders.cs
+++ b/Assetbundle/ProjectileBuilders.cs
@@ -13,26 +13,22 @@ namespace Alexandria.Assetbundle
     {
         public static List<T> ConstructListOfSameValues<T>(T value, int length)
         {
-            List<T> list = new List<T>();
-            for (int i = 0; i < length; i++)
-            {
-                list.Add(value);
-            }
-            return list;
+            return Enumerable.Repeat<T>(value, length).ToList();
         }
+
         public static tk2dSpriteDefinition SetProjectileCollisionRight(this Projectile proj, string name, tk2dSpriteCollectionData data, int pixelWidth, int pixelHeight, bool lightened = true, tk2dBaseSprite.Anchor anchor = tk2dBaseSprite.Anchor.LowerLeft, int? overrideColliderPixelWidth = null, int? overrideColliderPixelHeight = null, bool anchorChangesCollider = true, bool fixesScale = false, int? overrideColliderOffsetX = null, int? overrideColliderOffsetY = null, Projectile overrideProjectileToCopyFrom = null)
         {
             try
             {
                 proj.sprite.Collection = data;
                 proj.GetAnySprite().spriteId = data.GetSpriteIdByName(name);
-                tk2dSpriteDefinition def = SetupDefinitionForProjectileSprite(name, proj.GetAnySprite().spriteId, data, pixelWidth, pixelHeight, lightened, overrideColliderPixelWidth, overrideColliderPixelHeight, overrideColliderOffsetX,
-                    overrideColliderOffsetY, overrideProjectileToCopyFrom);
+                tk2dSpriteDefinition def = SetupDefinitionForProjectileSprite(name, proj.GetAnySprite().spriteId, data, pixelWidth, pixelHeight, lightened,
+                    overrideColliderPixelWidth, overrideColliderPixelHeight, overrideColliderOffsetX, overrideColliderOffsetY, overrideProjectileToCopyFrom);
 
                 def.ConstructOffsetsFromAnchor(anchor, def.position3, fixesScale, anchorChangesCollider);
-                proj.GetAnySprite().scale = new Vector3(1f, 1f, 1f);
-                proj.transform.localScale = new Vector3(1f, 1f, 1f);
-                proj.GetAnySprite().transform.localScale = new Vector3(1f, 1f, 1f);
+                proj.GetAnySprite().scale = Vector3.one;
+                proj.transform.localScale = Vector3.one;
+                proj.GetAnySprite().transform.localScale = Vector3.one;
                 proj.AdditionalScaleMultiplier = 1f;
                 return def;
             }
@@ -43,32 +39,20 @@ namespace Alexandria.Assetbundle
                 return null;
             }
         }
+
         private static tk2dSpriteDefinition SetupDefinitionForProjectileSprite(string name, int id, tk2dSpriteCollectionData data, int pixelWidth, int pixelHeight, bool lightened = true, int? overrideColliderPixelWidth = null, int? overrideColliderPixelHeight = null, int? overrideColliderOffsetX = null, int? overrideColliderOffsetY = null, Projectile overrideProjectileToCopyFrom = null)
         {
-            if (overrideColliderPixelWidth == null)
-            {
-                overrideColliderPixelWidth = pixelWidth;
-            }
-            if (overrideColliderPixelHeight == null)
-            {
-                overrideColliderPixelHeight = pixelHeight;
-            }
-            if (overrideColliderOffsetX == null)
-            {
-                overrideColliderOffsetX = 0;
-            }
-            if (overrideColliderOffsetY == null)
-            {
-                overrideColliderOffsetY = 0;
-            }
-            float thing = 16;
-            float thing2 = 16;
-            float trueWidth = (float)pixelWidth / thing;
-            float trueHeight = (float)pixelHeight / thing;
-            float colliderWidth = (float)overrideColliderPixelWidth.Value / thing2;
-            float colliderHeight = (float)overrideColliderPixelHeight.Value / thing2;
-            float colliderOffsetX = (float)overrideColliderOffsetX.Value / thing2;
-            float colliderOffsetY = (float)overrideColliderOffsetY.Value / thing2;
+            overrideColliderPixelWidth ??= pixelWidth;
+            overrideColliderPixelHeight ??= pixelHeight;
+            overrideColliderOffsetX ??= 0;
+            overrideColliderOffsetY ??= 0;
+
+            float trueWidth = 0.0625f * pixelWidth;
+            float trueHeight = 0.0625f * pixelHeight;
+            float colliderWidth = 0.0625f * overrideColliderPixelWidth.Value;
+            float colliderHeight = 0.0625f * overrideColliderPixelHeight.Value;
+            float colliderOffsetX = 0.0625f * overrideColliderOffsetX.Value;
+            float colliderOffsetY = 0.0625f * overrideColliderOffsetY.Value;
             tk2dSpriteDefinition def = ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[(overrideProjectileToCopyFrom ??
                     (PickupObjectDatabase.GetById(lightened ? 47 : 12) as Gun).DefaultModule.projectiles[0]).GetAnySprite().spriteId].CopyDefinitionFrom();
             def.boundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
@@ -91,111 +75,35 @@ namespace Alexandria.Assetbundle
             data.spriteDefinitions[id] = def;
             return def;
         }
+
         public static void AnimateProjectileBundle(this Projectile proj, string defaultClipName, tk2dSpriteCollectionData data, tk2dSpriteAnimation animation, string animationName, List<IntVector2> pixelSizes, List<bool> lighteneds, List<tk2dBaseSprite.Anchor> anchors, List<bool> anchorsChangeColliders, List<bool> fixesScales, List<Vector3?> manualOffsets, List<IntVector2?> overrideColliderPixelSizes, List<IntVector2?> overrideColliderOffsets, List<Projectile> overrideProjectilesToCopyFrom)
         {
-
             if (proj.sprite.spriteAnimator == null)
-            {
                 proj.sprite.spriteAnimator = proj.sprite.gameObject.AddComponent<tk2dSpriteAnimator>();
-            }
             proj.sprite.spriteAnimator.Library = animation;
-            if (defaultClipName != null)
-            {
-                proj.sprite.spriteAnimator.DefaultClipId = animation.GetClipIdByName(defaultClipName);
-            }
             proj.sprite.spriteAnimator.playAutomatically = true;
+            if (defaultClipName != null)
+                proj.sprite.spriteAnimator.DefaultClipId = animation.GetClipIdByName(defaultClipName);
 
-            for (int i = 0; i < animation.GetClipByName(animationName).frames.Length; i++)
+            var frames = animation.GetClipByName(animationName).frames;
+            if (frames == null || frames.Length == 0)
+                return;
+
+            proj.GetAnySprite().SetSprite(data, frames[0].spriteId);
+            for (int i = 0; i < frames.Length; i++)
             {
-                var frame = animation.GetClipByName(animationName).frames[i];
-
-                IntVector2 pixelSize = pixelSizes[i];
-                IntVector2? overrideColliderPixelSize = overrideColliderPixelSizes[i];
-                IntVector2? overrideColliderOffset = overrideColliderOffsets[i];
-                Vector3? manualOffset = manualOffsets[i];
-                bool anchorChangesCollider = anchorsChangeColliders[i];
-                bool fixesScale = fixesScales[i];
-                if (!manualOffset.HasValue)
+                tk2dSpriteDefinition def = SetupDefinitionForProjectileSprite(animationName, frames[i].spriteId, data, pixelSizes[i].x, pixelSizes[i].y, lighteneds[i],
+                    overrideColliderPixelSizes[i]?.x, overrideColliderPixelSizes[i]?.y, overrideColliderOffsets[i]?.x, overrideColliderOffsets[i]?.y,
+                    overrideProjectilesToCopyFrom[i]);
+                def.ConstructOffsetsFromAnchor(anchors[i], def.position3, fixesScales[i], anchorsChangeColliders[i]);
+                if (manualOffsets[i] is Vector3 manualOffset)
                 {
-                    manualOffset = new Vector2?(Vector2.zero);
-                }
-                tk2dBaseSprite.Anchor anchor = anchors[i];
-                bool lightened = lighteneds[i];
-                Projectile overrideProjectileToCopyFrom = overrideProjectilesToCopyFrom[i];
-                int? overrideColliderPixelWidth = null;
-                int? overrideColliderPixelHeight = null;
-                if (overrideColliderPixelSize.HasValue)
-                {
-                    overrideColliderPixelWidth = overrideColliderPixelSize.Value.x;
-                    overrideColliderPixelHeight = overrideColliderPixelSize.Value.y;
-                }
-                int? overrideColliderOffsetX = null;
-                int? overrideColliderOffsetY = null;
-                if (overrideColliderOffset.HasValue)
-                {
-                    overrideColliderOffsetX = overrideColliderOffset.Value.x;
-                    overrideColliderOffsetY = overrideColliderOffset.Value.y;
-                }
-                tk2dSpriteDefinition def = SetupDefinitionForProjectileSpriteBundle(animationName, frame.spriteId, data, pixelSize.x, pixelSize.y, lightened, overrideColliderPixelWidth, overrideColliderPixelHeight, overrideColliderOffsetX, overrideColliderOffsetY,
-                    overrideProjectileToCopyFrom);
-                def.ConstructOffsetsFromAnchor(anchor, def.position3, fixesScale, anchorChangesCollider);
-                def.position0 += manualOffset.Value;
-                def.position1 += manualOffset.Value;
-                def.position2 += manualOffset.Value;
-                def.position3 += manualOffset.Value;
-                if (i == 0)
-                {
-                    proj.GetAnySprite().SetSprite(data, frame.spriteId);
+                    def.position0 += manualOffset;
+                    def.position1 += manualOffset;
+                    def.position2 += manualOffset;
+                    def.position3 += manualOffset;
                 }
             }
-        }
-        private static tk2dSpriteDefinition SetupDefinitionForProjectileSpriteBundle(string name, int id, tk2dSpriteCollectionData data, int pixelWidth, int pixelHeight, bool lightened = true, int? overrideColliderPixelWidth = null, int? overrideColliderPixelHeight = null, int? overrideColliderOffsetX = null, int? overrideColliderOffsetY = null, Projectile overrideProjectileToCopyFrom = null)
-        {
-            if (overrideColliderPixelWidth == null)
-            {
-                overrideColliderPixelWidth = pixelWidth;
-            }
-            if (overrideColliderPixelHeight == null)
-            {
-                overrideColliderPixelHeight = pixelHeight;
-            }
-            if (overrideColliderOffsetX == null)
-            {
-                overrideColliderOffsetX = 0;
-            }
-            if (overrideColliderOffsetY == null)
-            {
-                overrideColliderOffsetY = 0;
-            }
-            float thing = 16;
-            float thing2 = 16;
-            float trueWidth = (float)pixelWidth / thing;
-            float trueHeight = (float)pixelHeight / thing;
-            float colliderWidth = (float)overrideColliderPixelWidth.Value / thing2;
-            float colliderHeight = (float)overrideColliderPixelHeight.Value / thing2;
-            float colliderOffsetX = (float)overrideColliderOffsetX.Value / thing2;
-            float colliderOffsetY = (float)overrideColliderOffsetY.Value / thing2;
-            tk2dSpriteDefinition def = ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[(overrideProjectileToCopyFrom ?? (PickupObjectDatabase.GetById(lightened ? 47 : 12) as Gun).DefaultModule.projectiles[0]).GetAnySprite().spriteId].CopyDefinitionFrom();
-
-            def.boundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
-            def.boundsDataExtents = new Vector3(trueWidth, trueHeight, 0f);
-            def.untrimmedBoundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
-            def.untrimmedBoundsDataExtents = new Vector3(trueWidth, trueHeight, 0f);
-            def.texelSize = new Vector2(1 / 16f, 1 / 16f);
-            def.position0 = new Vector3(0f, 0f, 0f);
-            def.position1 = new Vector3(0f + trueWidth, 0f, 0f);
-            def.position2 = new Vector3(0f, 0f + trueHeight, 0f);
-            def.position3 = new Vector3(0f + trueWidth, 0f + trueHeight, 0f);
-
-            def.materialInst.mainTexture = data.spriteDefinitions[id].materialInst.mainTexture;
-            def.uvs = data.spriteDefinitions[id].uvs.ToArray();
-
-            def.colliderVertices = new Vector3[2];
-            def.colliderVertices[0] = new Vector3(colliderOffsetX, colliderOffsetY, 0f);
-            def.colliderVertices[1] = new Vector3(colliderWidth / 2, colliderHeight / 2);
-            def.name = name;
-            data.spriteDefinitions[id] = def;
-            return def;
         }
 
         public static GameObject AddTrailToProjectileBundle(this Projectile target, tk2dSpriteCollectionData tk2DSpriteCollectionData, string spriteName, tk2dSpriteAnimation animationLibrary, string defaultAnimation, Vector2 colliderDimensions, Vector2 colliderOffsets, bool destroyOnEmpty = false, string startAnimationName = null,
@@ -203,58 +111,43 @@ namespace Alexandria.Assetbundle
         {
             try
             {
-
                 GameObject newTrailObject = PrefabBuilder.BuildObject("trailObject");
                 newTrailObject.transform.parent = target.transform;
                 newTrailObject.name = "trailObject";
-
-                float convertedColliderX = colliderDimensions.x / 16f;
-                float convertedColliderY = colliderDimensions.y / 16f;
-                float convertedOffsetX = colliderOffsets.x / 16f;
-                float convertedOffsetY = colliderOffsets.y / 16f;
 
                 tk2dTiledSprite tiledSprite = newTrailObject.GetOrAddComponent<tk2dTiledSprite>();
 
                 tiledSprite.SetSprite(tk2DSpriteCollectionData, tk2DSpriteCollectionData.GetSpriteIdByName(spriteName));
                 tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
-                def.colliderVertices = new Vector3[]{
-                    new Vector3(convertedOffsetX, convertedOffsetY, 0f),
-                    new Vector3(convertedColliderX, convertedColliderY, 0f)
-                };
-                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                def.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets, 0.0625f * colliderDimensions };
+                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft); //NOTE: this doesn't seem right, but maybe it is?
                 tk2dSpriteAnimator animator = newTrailObject.GetOrAddComponent<tk2dSpriteAnimator>();
                 animator.playAutomatically = true;
                 animator.defaultClipId = animationLibrary.GetClipIdByName(defaultAnimation);
                 animator.Library = animationLibrary;
 
                 TrailController trail = newTrailObject.AddComponent<TrailController>();
-                //---------------- Sets up the animation for the main part of the trail
-                if (defaultAnimation != null)
+                trail.usesAnimation = defaultAnimation != null;
+                if (trail.usesAnimation)
                 {
                     SetupBeamPart(animationLibrary, defaultAnimation, null, null, def.colliderVertices);
                     trail.animation = defaultAnimation;
-                    trail.usesAnimation = true;
-                }
-                else
-                {
-                    trail.usesAnimation = false;
                 }
 
-                if (startAnimationName != null)
+                trail.usesStartAnimation = startAnimationName != null;
+                if (trail.usesStartAnimation)
                 {
                     SetupBeamPart(animationLibrary, startAnimationName, null, null, def.colliderVertices);
                     trail.startAnimation = startAnimationName;
-                    trail.usesStartAnimation = true;
-                }
-                else
-                {
-                    trail.usesStartAnimation = false;
                 }
 
                 //Trail Variables
-                if (softMaxLength > 0) { trail.usesSoftMaxLength = true; trail.softMaxLength = softMaxLength; }
-                if (cascadeTimer > 0) { trail.usesCascadeTimer = true; trail.cascadeTimer = cascadeTimer; }
-                trail.usesGlobalTimer = true; trail.globalTimer = timeTillAnimStart;
+                trail.usesSoftMaxLength = (softMaxLength > 0);
+                trail.softMaxLength = softMaxLength;
+                trail.usesCascadeTimer = (cascadeTimer > 0);
+                trail.cascadeTimer = cascadeTimer;
+                trail.usesGlobalTimer = true;
+                trail.globalTimer = timeTillAnimStart;
                 trail.destroyOnEmpty = destroyOnEmpty;
                 return newTrailObject;
             }

--- a/Assetbundle/ProjectileBuilders.cs
+++ b/Assetbundle/ProjectileBuilders.cs
@@ -1,5 +1,6 @@
 ﻿using Alexandria.ItemAPI;
 using Alexandria.PrefabAPI;
+using Alexandria.Misc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -265,31 +266,12 @@ namespace Alexandria.Assetbundle
         }
         private static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, string animationName, Vector2? colliderDimensions = null, Vector2? colliderOffsets = null, Vector3[] overrideVertices = null)
         {
-            foreach (var path in beamAnimation.GetClipByName(animationName).frames)
-            {
-                tk2dSpriteDefinition frameDef = path.spriteCollection.spriteDefinitions[path.spriteId];
-                frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
-                if (overrideVertices != null)
-                {
-                    frameDef.colliderVertices = overrideVertices;
-                }
-                else
-                {
-                    if (colliderDimensions == null || colliderOffsets == null)
-                    {
-                        ETGModConsole.Log("<size=100><color=#ff0000ff>BEAM ERROR: colliderDimensions or colliderOffsets was null with no override vertices!</color></size>", false);
-                    }
-                    else
-                    {
-                        Vector2 actualDimensions = (Vector2)colliderDimensions;
-                        Vector2 actualOffsets = (Vector2)colliderDimensions;
-                        frameDef.colliderVertices = new Vector3[]{
-                            new Vector3(actualOffsets.x / 16, actualOffsets.y / 16, 0f),
-                            new Vector3(actualDimensions.x / 16, actualDimensions.y / 16, 0f)
-                        };
-                    }
-                }
-            }
+            if (beamAnimation.GetClipByName(animationName) is not tk2dSpriteAnimationClip clip)
+                return;
+            if (clip.frames == null || clip.frames.Length == 0)
+                return;
+            Shared.SetupBeamPart(beamAnimation, clip.frames[0].spriteCollection, animationName, colliderDimensions, colliderOffsets, overrideVertices,
+                tk2dSpriteAnimationClip.WrapMode.Once, anchor: tk2dBaseSprite.Anchor.MiddleLeft); //NOTE: a third different offset
         }
     }
 

--- a/BreakableAPI/BreakableAPIToolbox.cs
+++ b/BreakableAPI/BreakableAPIToolbox.cs
@@ -11,6 +11,7 @@ using Gungeon;
 using FullInspector;
 using Brave.BulletScript;
 using Alexandria.ItemAPI;
+using Alexandria.Misc;
 
 namespace Alexandria.BreakableAPI
 {
@@ -124,7 +125,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 idleClip.frames = frames.ToArray();
                 idleClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -151,7 +152,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(activationSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     unsealFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
 
                 for (int i = 0; i < activeIdleSpritePaths.Length; i++)
@@ -160,7 +161,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(activeIdleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     unsealFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 unsealClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.LoopSection;
                 unsealClip.loopStart = activationSpritePaths.Length;
@@ -270,7 +271,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 idleClip.frames = frames.ToArray();
                 idleClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -296,7 +297,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(sealSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     sealFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 sealClip.frames = sealFrames.ToArray();
                 sealClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Once;
@@ -315,7 +316,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(unsealSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     unsealFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 unsealClip.frames = unsealFrames.ToArray();
                 unsealClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Once;
@@ -334,7 +335,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(playerNearSealedDoorAnimPaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     playernearblockerFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 playernearblockerClip.frames = playernearblockerFrames.ToArray();
                 playernearblockerClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -387,7 +388,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 idleClip.frames = frames.ToArray();
                 idleClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -414,7 +415,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(sealSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     sealFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 sealClip.frames = sealFrames.ToArray();
                 sealClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Once;
@@ -433,7 +434,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(unsealSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     unsealFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 unsealClip.frames = unsealFrames.ToArray();
                 unsealClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Once;
@@ -452,7 +453,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(playerNearSealedDoorAnimPaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     playernearblockerFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 playernearblockerClip.frames = playernearblockerFrames.ToArray();
                 playernearblockerClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -524,7 +525,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 idleClip.frames = frames.ToArray();
                 idleClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -574,18 +575,8 @@ namespace Alexandria.BreakableAPI
 
         public static tk2dSpriteAnimationClip AddAnimation(string clipName, tk2dSpriteAnimator animator, tk2dSpriteAnimation animation, int FPS, string[] SpritePaths, tk2dSpriteCollectionData SpriteObjectSpriteCollection, tk2dSpriteAnimationClip.WrapMode wrapMode)
         {
-            tk2dSpriteAnimationClip clip = new tk2dSpriteAnimationClip() { name = clipName, frames = new tk2dSpriteAnimationFrame[0], fps = FPS };
-            List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-            for (int i = 0; i < SpritePaths.Length; i++)
-            {
-                tk2dSpriteCollectionData collection = SpriteObjectSpriteCollection;
-                int frameSpriteId = SpriteBuilder.AddSpriteToCollection(SpritePaths[i], collection, Assembly.GetCallingAssembly());
-                tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
-            }
-            clip.frames = frames.ToArray();
-            clip.wrapMode = wrapMode;
+            var clip = Shared.CreateAnimation(Assembly.GetCallingAssembly(), SpriteObjectSpriteCollection, new List<string>(SpritePaths),
+                clipName, wrapMode, FPS, offsetAnchor: tk2dBaseSprite.Anchor.LowerLeft);
             animator.Library.clips = animation.clips.Concat(new tk2dSpriteAnimationClip[] { clip }).ToArray();
             return clip;
         }
@@ -610,39 +601,33 @@ namespace Alexandria.BreakableAPI
             sprite.SetSprite(SpriteObjectSpriteCollection, spriteID);
 
             tk2dSpriteAnimator animator = gameObject.GetOrAddComponent<tk2dSpriteAnimator>();
-            tk2dSpriteAnimation animation = gameObject.AddComponent<tk2dSpriteAnimation>();
+            tk2dSpriteAnimation animation = gameObject.GetOrAddComponent<tk2dSpriteAnimation>();
             animation.clips = new tk2dSpriteAnimationClip[0];
             animator.Library = animation;
 
-            List<tk2dSpriteAnimationClip> clips = new List<tk2dSpriteAnimationClip>();
-            if (SpritePaths.Length >= 1)
+            if (SpritePaths.Length == 0)
+                return gameObject;
+
+            Assembly assembly = Assembly.GetCallingAssembly();
+            tk2dSpriteCollectionData collection = SpriteObjectSpriteCollection;
+            tk2dSpriteAnimationClip idleClip = new tk2dSpriteAnimationClip() {
+                name = "idle",
+                frames = new tk2dSpriteAnimationFrame[SpritePaths.Length],
+                fps = AnimFPS,
+                wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop,
+            };
+            for (int i = 0; i < SpritePaths.Length; i++)
             {
-                tk2dSpriteAnimationClip idleClip = new tk2dSpriteAnimationClip() { name = "idle", frames = new tk2dSpriteAnimationFrame[0], fps = AnimFPS };
-                List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-                for (int i = 0; i < SpritePaths.Length; i++)
-                {
-                    tk2dSpriteCollectionData collection = SpriteObjectSpriteCollection;
-                    int frameSpriteId = SpriteBuilder.AddSpriteToCollection(SpritePaths[i], collection, Assembly.GetCallingAssembly());
-                    tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                    frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
-                }
-                idleClip.frames = frames.ToArray();
-                idleClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
-                animator.Library.clips = animation.clips.Concat(new tk2dSpriteAnimationClip[] { idleClip }).ToArray();
-                animator.playAutomatically = true;
-                animator.DefaultClipId = animator.GetClipIdByName("idle");
-                clips.Add(idleClip);
-                tk2dSpriteAnimationClip[] array = clips.ToArray();
-                animator.Library.clips = array;
-                animator.playAutomatically = true;
-                animator.DefaultClipId = animator.GetClipIdByName("idle");
+                int frameSpriteId = SpriteBuilder.AddSpriteToCollection(SpritePaths[i], collection, assembly);
+                tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
+                idleClip.frames[i] = new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection };
+                Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
             }
+            animator.Library.clips = new tk2dSpriteAnimationClip[]{idleClip};
+            animator.playAutomatically = true;
+            animator.DefaultClipId = animator.GetClipIdByName("idle");
             return gameObject;
         }
-
-
-
 
         /// <summary>
         /// Generates, and returns a KickableObject. This is for generating a basic one, it returns it so you can additionally modify it without cluttering up the setup method too much. Reminder, KickableObjects have a MinorBreakable component that you could modify as well!
@@ -775,7 +760,7 @@ namespace Alexandria.BreakableAPI
                     tk2dSpriteCollectionData collection = KickableSpriteCollection;
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
                 }
                 idleClip.frames = frames.ToArray();
@@ -832,21 +817,10 @@ namespace Alexandria.BreakableAPI
         }
         private static tk2dSpriteAnimationClip AddAnimation(tk2dSpriteAnimator animator, tk2dSpriteCollectionData Tablecollection, string[] spritePaths, string clipName, int FPS, tk2dSpriteAnimationClip.WrapMode wrapMode)
         {
-            tk2dSpriteAnimation animation = animator.gameObject.AddComponent<tk2dSpriteAnimation>();
+            tk2dSpriteAnimation animation = animator.gameObject.AddComponent<tk2dSpriteAnimation>(); //NOTE: this doesn't seem right...
             animation.clips = new tk2dSpriteAnimationClip[0];
             animator.Library = animation;
-            tk2dSpriteAnimationClip idleClip = new tk2dSpriteAnimationClip() { name = clipName, frames = new tk2dSpriteAnimationFrame[0], fps = FPS };
-            List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-            for (int i = 0; i < spritePaths.Length; i++)
-            {
-                tk2dSpriteCollectionData collection = Tablecollection;
-                int frameSpriteId = SpriteBuilder.AddSpriteToCollection(spritePaths[i], collection, Assembly.GetCallingAssembly());
-                tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-            }
-            idleClip.frames = frames.ToArray();
-            idleClip.wrapMode = wrapMode;
-            return idleClip;
+            return Shared.CreateAnimation(Assembly.GetCallingAssembly(), Tablecollection, new List<string>(spritePaths), clipName, wrapMode, FPS);
         }
 
         /// <summary>
@@ -939,7 +913,7 @@ namespace Alexandria.BreakableAPI
                     tk2dSpriteCollectionData collection = TableCollection;
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                     tk2dSpriteDefinition frameDefMod = GenerateColliderForSpriteDefinition(frameDef, new Vector3(colliderSize.x, colliderSize.y), new Vector3(colliderOffset.x, colliderOffset.y));
                     frameDef = frameDefMod;
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
@@ -1195,7 +1169,7 @@ namespace Alexandria.BreakableAPI
                 tk2dSpriteCollectionData collection = Tablecollection;
                 int frameSpriteId = SpriteBuilder.AddSpriteToCollection(spritePaths[i], collection, Assembly.GetCallingAssembly());
                 tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
 
                 if (clipName.Contains("break"))
                 {
@@ -1415,7 +1389,7 @@ namespace Alexandria.BreakableAPI
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                 }
                 idleClip.frames = frames.ToArray();
                 idleClip.wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop;
@@ -1435,7 +1409,7 @@ namespace Alexandria.BreakableAPI
                     tk2dSpriteCollectionData collection = MajorBreakableSpriteCollection;
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(breakSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                     breakFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
                 }
                 breakClip.frames = breakFrames.ToArray();
@@ -1578,7 +1552,7 @@ namespace Alexandria.BreakableAPI
                     tk2dSpriteCollectionData collection = MinorBreakableSpriteCollection;
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(idleSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                     frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
                 }
                 idleClip.frames = frames.ToArray();
@@ -1599,7 +1573,7 @@ namespace Alexandria.BreakableAPI
                     tk2dSpriteCollectionData collection = MinorBreakableSpriteCollection;
                     int frameSpriteId = SpriteBuilder.AddSpriteToCollection(breakSpritePaths[i], collection, Assembly.GetCallingAssembly());
                     tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                    frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.LowerLeft);
+                    Shared.ConstructOffsetsFromAnchor(frameDef, tk2dBaseSprite.Anchor.LowerLeft);
                     breakFrames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
                 }
                 breakClip.frames = breakFrames.ToArray();

--- a/CharApi/CharacterBuilding/SpriteHandler.cs
+++ b/CharApi/CharacterBuilding/SpriteHandler.cs
@@ -473,7 +473,7 @@ namespace Alexandria.CharacterAPI
         /// <returns>A new sprite definition with the given texture</returns>
         public static tk2dSpriteDefinition ConstructDefinition(Texture2D texture, Material overrideMat = null)
         {
-            return SharedExtensions.ConstructDefinition(texture: texture, overrideMat: overrideMat, apply: true, useOffset: false);
+            return Shared.ConstructDefinition(texture: texture, overrideMat: overrideMat, apply: true, useOffset: false);
         }
 
         public static Texture2D AddOutlineToTexture(Texture2D sprite, Color color)
@@ -1057,19 +1057,19 @@ namespace Alexandria.CharacterAPI
             {
                 definition.name = name; //naming the definition is actually extremely important 
             }
-            SharedExtensions.ConstructOffsetsFromAnchor(definition, anchor);
+            Shared.ConstructOffsetsFromAnchor(definition, anchor);
 
             return AddSpriteToCollection(definition, collection);
         }
 
         public static void ConstructOffsetsFromAnchorC(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
-            SharedExtensions.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, false);
+            Shared.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, false);
         }
 
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            SharedExtensions.MakeOffset(def, offset, changesCollider);
+            Shared.MakeOffset(def, offset, changesCollider);
         }
 
         /// <summary>

--- a/CharApi/CharacterBuilding/SpriteHandler.cs
+++ b/CharApi/CharacterBuilding/SpriteHandler.cs
@@ -473,71 +473,7 @@ namespace Alexandria.CharacterAPI
         /// <returns>A new sprite definition with the given texture</returns>
         public static tk2dSpriteDefinition ConstructDefinition(Texture2D texture, Material overrideMat = null)
         {
-            RuntimeAtlasSegment ras = ETGMod.Assets.Packer.Pack(texture, true); //pack your resources beforehand or the outlines will turn out weird
-
-            Material material = null;
-            if (overrideMat != null)
-            {
-                material = overrideMat;
-            }
-            else
-            {
-                material = new Material(ShaderCache.Acquire(PlayerController.DefaultShaderName));
-            }
-            material.mainTexture = ras.texture;
-            //material.mainTexture = texture;
-
-            var width = texture.width;
-            var height = texture.height;
-
-            var x = 0f;
-            var y = 0f;
-
-            var w = width / 16f;
-            var h = height / 16f;
-
-            var def = new tk2dSpriteDefinition
-            {
-                normals = new Vector3[] {
-                new Vector3(0.0f, 0.0f, -1.0f),
-                new Vector3(0.0f, 0.0f, -1.0f),
-                new Vector3(0.0f, 0.0f, -1.0f),
-                new Vector3(0.0f, 0.0f, -1.0f),
-            },
-                tangents = new Vector4[] {
-                new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
-                new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
-                new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
-                new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
-            },
-                texelSize = new Vector2(1 / 16f, 1 / 16f),
-                extractRegion = false,
-                regionX = 0,
-                regionY = 0,
-                regionW = 0,
-                regionH = 0,
-                flipped = tk2dSpriteDefinition.FlipMode.None,
-                complexGeometry = false,
-                physicsEngine = tk2dSpriteDefinition.PhysicsEngine.Physics3D,
-                colliderType = tk2dSpriteDefinition.ColliderType.None,
-                collisionLayer = CollisionLayer.HighObstacle,
-                position0 = new Vector3(x, y, 0f),
-                position1 = new Vector3(x + w, y, 0f),
-                position2 = new Vector3(x, y + h, 0f),
-                position3 = new Vector3(x + w, y + h, 0f),
-                material = material,
-                materialInst = material,
-                materialId = 0,
-                //uvs = ETGMod.Assets.GenerateUVs(texture, 0, 0, width, height), //uv machine broke
-                uvs = ras.uvs,
-                boundsDataCenter = new Vector3(w / 2f, h / 2f, 0f),
-                boundsDataExtents = new Vector3(w, h, 0f),
-                untrimmedBoundsDataCenter = new Vector3(w / 2f, h / 2f, 0f),
-                untrimmedBoundsDataExtents = new Vector3(w, h, 0f),
-            };
-
-            def.name = texture.name;
-            return def;
+            return SharedExtensions.ConstructDefinition(texture: texture, overrideMat: overrideMat, apply: true, useOffset: false);
         }
 
         public static Texture2D AddOutlineToTexture(Texture2D sprite, Color color)

--- a/CharApi/CharacterBuilding/SpriteHandler.cs
+++ b/CharApi/CharacterBuilding/SpriteHandler.cs
@@ -1121,43 +1121,15 @@ namespace Alexandria.CharacterAPI
             {
                 definition.name = name; //naming the definition is actually extremely important 
             }
-            definition.ConstructOffsetsFromAnchor(anchor);
+            SharedExtensions.ConstructOffsetsFromAnchor(definition, anchor);
 
             return AddSpriteToCollection(definition, collection);
         }
 
         public static void ConstructOffsetsFromAnchorC(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
-            if (!scale.HasValue)
-            {
-                scale = new Vector2?(def.position3);
-            }
-            if (fixesScale)
-            {
-                Vector2 fixedScale = scale.Value - def.position0.XY();
-                scale = new Vector2?(fixedScale);
-            }
-            float xOffset = 0;
-            if (anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.UpperCenter)
-            {
-                xOffset = -(scale.Value.x / 2f);
-            }
-            else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
-            {
-                xOffset = -scale.Value.x;
-            }
-            float yOffset = 0;
-            if (anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.MiddleLeft)
-            {
-                yOffset = -(scale.Value.y / 2f);
-            }
-            else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
-            {
-                yOffset = -scale.Value.y;
-            }
-            def.MakeOffset(new Vector2(xOffset, yOffset), changesCollider);
+            SharedExtensions.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, false);
         }
-
 
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {

--- a/CharApi/CharacterBuilding/SpriteHandler.cs
+++ b/CharApi/CharacterBuilding/SpriteHandler.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 
 using System;
 using Alexandria.ItemAPI;
+using Alexandria.Misc;
 using System.IO;
 using Microsoft.Cci;
 using Pathfinding;
@@ -1160,20 +1161,7 @@ namespace Alexandria.CharacterAPI
 
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            float xOffset = offset.x;
-            float yOffset = offset.y;
-            def.position0 += new Vector3(xOffset, yOffset, 0);
-            def.position1 += new Vector3(xOffset, yOffset, 0);
-            def.position2 += new Vector3(xOffset, yOffset, 0);
-            def.position3 += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            if (def.colliderVertices != null && def.colliderVertices.Length > 0 && changesCollider)
-            {
-                def.colliderVertices[0] += new Vector3(xOffset, yOffset, 0);
-            }
+            SharedExtensions.MakeOffset(def, offset, changesCollider);
         }
 
         /// <summary>

--- a/ItemAPI/ApplyOffset.cs
+++ b/ItemAPI/ApplyOffset.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 using Alexandria.ItemAPI;
+using Alexandria.Misc;
 
 namespace Alexandria.ItemAPI
 {
@@ -11,16 +12,7 @@ namespace Alexandria.ItemAPI
     {
        public static void ApplyOffset(this tk2dSpriteDefinition def, Vector2 offset)
         {
-            float xOffset = offset.x;
-            float yOffset = offset.y;
-            def.position0 += new Vector3(xOffset, yOffset, 0);
-            def.position1 += new Vector3(xOffset, yOffset, 0);
-            def.position2 += new Vector3(xOffset, yOffset, 0);
-            def.position3 += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataExtents += new Vector3(xOffset, yOffset, 0);
+            SharedExtensions.MakeOffset(def, offset);
         }
     }
 }

--- a/ItemAPI/ApplyOffset.cs
+++ b/ItemAPI/ApplyOffset.cs
@@ -12,7 +12,7 @@ namespace Alexandria.ItemAPI
     {
        public static void ApplyOffset(this tk2dSpriteDefinition def, Vector2 offset)
         {
-            SharedExtensions.MakeOffset(def, offset);
+            Shared.MakeOffset(def, offset);
         }
     }
 }

--- a/ItemAPI/ApplyOffset.cs
+++ b/ItemAPI/ApplyOffset.cs
@@ -10,7 +10,7 @@ namespace Alexandria.ItemAPI
 {
     public static class ApplyOffsetStuff
     {
-       public static void ApplyOffset(this tk2dSpriteDefinition def, Vector2 offset)
+        public static void ApplyOffset(this tk2dSpriteDefinition def, Vector2 offset)
         {
             Shared.MakeOffset(def, offset);
         }

--- a/ItemAPI/BeamAPI.cs
+++ b/ItemAPI/BeamAPI.cs
@@ -232,40 +232,7 @@ namespace Alexandria.ItemAPI
         /// <param name="overrideVertices">A set of override colliders, if applicable.</param>
         public static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, List<string> animSpritePaths, string animationName, int fps, Assembly assembly, Vector2? colliderDimensions = null, Vector2? colliderOffsets = null, Vector3[] overrideVertices = null)
         {
-            tk2dSpriteAnimationClip clip = new tk2dSpriteAnimationClip() { name = animationName, frames = new tk2dSpriteAnimationFrame[0], fps = fps };
-            List<string> spritePaths = animSpritePaths;
-
-            List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-            foreach (string path in spritePaths)
-            {
-                tk2dSpriteCollectionData collection = ETGMod.Databases.Items.ProjectileCollection;
-                int frameSpriteId = SpriteBuilder.AddSpriteToCollection(path, collection, assembly);
-                tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
-                frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleCenter);
-                if (overrideVertices != null)
-                {
-                    frameDef.colliderVertices = overrideVertices;
-                }
-                else
-                {
-                    if (colliderDimensions == null || colliderOffsets == null)
-                    {
-                        ETGModConsole.Log("<size=100><color=#ff0000ff>BEAM ERROR: colliderDimensions or colliderOffsets was null with no override vertices!</color></size>", false);
-                    }
-                    else
-                    {
-                        Vector2 actualDimensions = (Vector2)colliderDimensions;
-                        Vector2 actualOffsets = (Vector2)colliderDimensions;
-                        frameDef.colliderVertices = new Vector3[]{
-                            new Vector3(actualOffsets.x / 16, actualOffsets.y / 16, 0f),
-                            new Vector3(actualDimensions.x / 16, actualDimensions.y / 16, 0f)
-                        };
-                    }
-                }
-                frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
-            }
-            clip.frames = frames.ToArray();
-            beamAnimation.clips = beamAnimation.clips.Concat(new tk2dSpriteAnimationClip[] { clip }).ToArray();
+            Shared.SetupBeamPart(beamAnimation, animSpritePaths, animationName, fps, assembly, colliderDimensions, colliderOffsets, overrideVertices, anchor: tk2dBaseSprite.Anchor.MiddleCenter);
         }
 
         //Methods and extensions related to spawning beam prefabs at runtime

--- a/ItemAPI/BeamAPI.cs
+++ b/ItemAPI/BeamAPI.cs
@@ -23,10 +23,8 @@ namespace Alexandria.ItemAPI
         public static bool PosIsNearAnyBoneOnBeam(this BasicBeamController beam, Vector2 positionToCheck, float distance)
         {
             foreach (BasicBeamController.BeamBone bone in beam.m_bones)
-            {
-                Vector2 bonepos = beam.GetBonePosition(bone);
-                if (Vector2.Distance(positionToCheck, bonepos) < distance) return true;
-            }           
+                if (Vector2.Distance(positionToCheck, beam.GetBonePosition(bone)) < distance)
+                    return true;
             return false;
         }
 
@@ -36,8 +34,7 @@ namespace Alexandria.ItemAPI
         /// <param name="beam">The beam whose bones should be counted.</param>
         public static int GetBoneCount(this BasicBeamController beam)
         {
-            if (!beam.UsesBones) { return 1; }
-            else { return beam.m_bones.Count(); }
+            return beam.UsesBones ? beam.m_bones.Count() : 1;
         }
 
         /// <summary>
@@ -46,8 +43,7 @@ namespace Alexandria.ItemAPI
         /// <param name="beam">The beam to be checked.</param>
         public static float GetFinalBoneDirection(this BasicBeamController beam)
         {
-            if (!beam.UsesBones) { return beam.Direction.ToAngle(); }
-            else { return beam.m_bones.Last.Value.RotationAngle; }
+            return beam.UsesBones ? beam.m_bones.Last.Value.RotationAngle : beam.Direction.ToAngle();
         }
 
         /// <summary>
@@ -57,9 +53,12 @@ namespace Alexandria.ItemAPI
         /// <param name="boneIndex">The index whose bone should be returned..</param>
         public static BasicBeamController.BeamBone GetIndexedBone(this BasicBeamController beam, int boneIndex)
         {
-            if (beam.m_bones == null) return null;
-            if (beam.m_bones.ElementAt(boneIndex) == null) { Debug.LogError("Attempted to fetch a beam bone at an invalid index"); return null; }
-            return beam.m_bones.ElementAt(boneIndex);
+            if (beam.m_bones == null)
+                return null;
+            if (beam.m_bones.ElementAt(boneIndex) is BasicBeamController.BeamBone bone)
+                return bone;
+            Debug.LogError("Attempted to fetch a beam bone at an invalid index");
+            return null;
         }
 
         /// <summary>
@@ -70,16 +69,10 @@ namespace Alexandria.ItemAPI
         /// <param name="boneIndex">The index whose bone position should be returned..</param>
         public static Vector2 GetIndexedBonePosition(this BasicBeamController beam, int boneIndex)
         {
-            if (beam.m_bones.ElementAt(boneIndex) == null) { Debug.LogError("Attempted to fetch the position of a beam bone at an invalid index"); return Vector2.zero; }
-            if (!beam.UsesBones)
-            {
-                return beam.Origin + BraveMathCollege.DegreesToVector(beam.Direction.ToAngle(), beam.m_bones.ElementAt(boneIndex).PosX);
-            }
-            if (beam.ProjectileAndBeamMotionModule != null)
-            {
-                return beam.m_bones.ElementAt(boneIndex).Position + beam.ProjectileAndBeamMotionModule.GetBoneOffset(beam.m_bones.ElementAt(boneIndex), beam, beam.projectile.Inverted);
-            }
-            return beam.m_bones.ElementAt(boneIndex).Position;
+            if (beam.m_bones.ElementAt(boneIndex) is BasicBeamController.BeamBone bone)
+                return beam.GetBonePosition(bone);
+            Debug.LogError("Attempted to fetch the position of a beam bone at an invalid index");
+            return Vector2.zero;
         }
 
         /// <summary>
@@ -89,8 +82,10 @@ namespace Alexandria.ItemAPI
         /// <param name="bone">The bone whose position should be returned.</param>
         public static Vector2 GetBonePosition(this BasicBeamController beam, BasicBeamController.BeamBone bone)
         {
-            if (!beam.UsesBones) { return beam.Origin + BraveMathCollege.DegreesToVector(beam.Direction.ToAngle(), bone.PosX); }
-            if (beam.ProjectileAndBeamMotionModule != null) { return bone.Position + beam.ProjectileAndBeamMotionModule.GetBoneOffset(bone, beam, beam.projectile.Inverted); }
+            if (!beam.UsesBones)
+                return beam.Origin + BraveMathCollege.DegreesToVector(beam.Direction.ToAngle(), bone.PosX);
+            if (beam.ProjectileAndBeamMotionModule != null)
+                return bone.Position + beam.ProjectileAndBeamMotionModule.GetBoneOffset(bone, beam, beam.projectile.Inverted);
             return bone.Position;
         }
 
@@ -124,27 +119,23 @@ namespace Alexandria.ItemAPI
         {
             try
             {
-                projectile.specRigidbody.CollideWithOthers = false;
-                float convertedColliderX = colliderDimensions.x / 16f;
-                float convertedColliderY = colliderDimensions.y / 16f;
-                float convertedOffsetX = colliderOffsets.x / 16f;
-                float convertedOffsetY = colliderOffsets.y / 16f;
+                Assembly assembly = Assembly.GetCallingAssembly();
+
+                if (projectile.specRigidbody)
+                    projectile.specRigidbody.CollideWithOthers = false;
 
                 int spriteID = SpriteBuilder.AddSpriteToCollection(spritePath, ETGMod.Databases.Items.ProjectileCollection, Assembly.GetCallingAssembly());
                 tk2dTiledSprite tiledSprite = projectile.gameObject.GetOrAddComponent<tk2dTiledSprite>();
 
-
-
                 tiledSprite.SetSprite(ETGMod.Databases.Items.ProjectileCollection, spriteID);
                 tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
                 def.colliderVertices = new Vector3[]{
-                    new Vector3(convertedOffsetX, convertedOffsetY, 0f),
-                    new Vector3(convertedColliderX, convertedColliderY, 0f)
+                    0.0625f * colliderOffsets,
+                    0.0625f * colliderDimensions
                 };
 
-                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft);
+                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft); //NOTE: this seems right, but double check later
 
-                //tiledSprite.anchor = tk2dBaseSprite.Anchor.MiddleCenter;
                 tk2dSpriteAnimator animator = projectile.gameObject.GetOrAddComponent<tk2dSpriteAnimator>();
                 tk2dSpriteAnimation animation = projectile.gameObject.GetOrAddComponent<tk2dSpriteAnimation>();
                 animation.clips = new tk2dSpriteAnimationClip[0];
@@ -155,54 +146,41 @@ namespace Alexandria.ItemAPI
                 //---------------- Sets up the animation for the main part of the beam
                 if (beamAnimationPaths != null)
                 {
-                    tk2dSpriteAnimationClip clip = new tk2dSpriteAnimationClip() { name = "beam_idle", frames = new tk2dSpriteAnimationFrame[0], fps = beamFPS };
-                    List<string> spritePaths = beamAnimationPaths;
-
-                    List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-                    foreach (string path in spritePaths)
+                    tk2dSpriteAnimationClip clip = new tk2dSpriteAnimationClip() {
+                        name = "beam_idle", frames = new tk2dSpriteAnimationFrame[beamAnimationPaths.Count], fps = beamFPS };
+                    tk2dSpriteCollectionData collection = ETGMod.Databases.Items.ProjectileCollection;
+                    for (int i = 0; i < beamAnimationPaths.Count; ++i)
                     {
-                        tk2dSpriteCollectionData collection = ETGMod.Databases.Items.ProjectileCollection;
-                        int frameSpriteId = SpriteBuilder.AddSpriteToCollection(path, collection, Assembly.GetCallingAssembly());
+                        int frameSpriteId = SpriteBuilder.AddSpriteToCollection(beamAnimationPaths[i], collection, assembly);
                         tk2dSpriteDefinition frameDef = collection.spriteDefinitions[frameSpriteId];
                         frameDef.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft);
                         frameDef.colliderVertices = def.colliderVertices;
-                        frames.Add(new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection });
+                        clip.frames[i] = new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = collection };
                     }
-                    clip.frames = frames.ToArray();
                     animation.clips = animation.clips.Concat(new tk2dSpriteAnimationClip[] { clip }).ToArray();
                     beamController.beamAnimation = "beam_idle";
                 }
 
                 //------------- Sets up the animation for the part of the beam that touches the wall
                 if (endVFXAnimationPaths != null && endVFXColliderDimensions != null && endVFXColliderOffsets != null)
-                {
-                    SetupBeamPart(animation, endVFXAnimationPaths, "beam_end", beamEndFPS, Assembly.GetCallingAssembly(),(Vector2)endVFXColliderDimensions, (Vector2)endVFXColliderOffsets);
-                    beamController.beamEndAnimation = "beam_end";
-                }
+                    SetupBeamPart(animation, endVFXAnimationPaths, "beam_end", beamEndFPS, assembly, (Vector2)endVFXColliderDimensions, (Vector2)endVFXColliderOffsets);
                 else
-                {
-                    SetupBeamPart(animation, beamAnimationPaths, "beam_end", beamFPS, Assembly.GetCallingAssembly(), null, null, def.colliderVertices);
-                    beamController.beamEndAnimation = "beam_end";
-                }
+                    SetupBeamPart(animation, beamAnimationPaths, "beam_end", beamFPS, assembly, null, null, def.colliderVertices);
+                beamController.beamEndAnimation = "beam_end";
 
                 //---------------Sets up the animaton for the VFX that plays over top of the end of the beam where it hits stuff
                 if (impactVFXAnimationPaths != null && impactVFXColliderDimensions != null && impactVFXColliderOffsets != null)
                 {
-                    SetupBeamPart(animation, impactVFXAnimationPaths, "beam_impact", beamImpactFPS, Assembly.GetCallingAssembly(), (Vector2)impactVFXColliderDimensions, (Vector2)impactVFXColliderOffsets);
+                    SetupBeamPart(animation, impactVFXAnimationPaths, "beam_impact", beamImpactFPS, assembly, (Vector2)impactVFXColliderDimensions, (Vector2)impactVFXColliderOffsets);
                     beamController.impactAnimation = "beam_impact";
                 }
 
                 //--------------Sets up the animation for the very start of the beam
                 if (muzzleVFXAnimationPaths != null && muzzleVFXColliderDimensions != null && muzzleVFXColliderOffsets != null)
-                {
-                    SetupBeamPart(animation, muzzleVFXAnimationPaths, "beam_start", beamMuzzleFPS, Assembly.GetCallingAssembly(), (Vector2)muzzleVFXColliderDimensions, (Vector2)muzzleVFXColliderOffsets);
-                    beamController.beamStartAnimation = "beam_start";
-                }
+                    SetupBeamPart(animation, muzzleVFXAnimationPaths, "beam_start", beamMuzzleFPS, assembly, (Vector2)muzzleVFXColliderDimensions, (Vector2)muzzleVFXColliderOffsets);
                 else
-                {
-                    SetupBeamPart(animation, beamAnimationPaths, "beam_start", beamFPS, Assembly.GetCallingAssembly(), null, null, def.colliderVertices);
-                    beamController.beamStartAnimation = "beam_start";
-                }
+                    SetupBeamPart(animation, beamAnimationPaths, "beam_start", beamFPS, assembly, null, null, def.colliderVertices);
+                beamController.beamStartAnimation = "beam_start";
 
                 if (glowAmount > 0)
                 {
@@ -253,35 +231,38 @@ namespace Alexandria.ItemAPI
         {
             Vector2 sourcePos = Vector2.zero;
             SpeculativeRigidbody rigidBod = null;
-            if (otherShooter == null) sourcePos = fixedPosition;
+            if (otherShooter == null)
+                sourcePos = fixedPosition;
             else
             {
-                if (otherShooter.GetComponent<SpeculativeRigidbody>()) rigidBod = otherShooter.GetComponent<SpeculativeRigidbody>();
-                else if (otherShooter.GetComponentInChildren<SpeculativeRigidbody>()) rigidBod = otherShooter.GetComponentInChildren<SpeculativeRigidbody>();
-
-                if (rigidBod) sourcePos = rigidBod.UnitCenter;
+                if (otherShooter.GetComponent<SpeculativeRigidbody>() is SpeculativeRigidbody body1)
+                    rigidBod = body1;
+                else if (otherShooter.GetComponentInChildren<SpeculativeRigidbody>() is SpeculativeRigidbody body2)
+                    rigidBod = body2;
+                if (rigidBod)
+                    sourcePos = rigidBod.UnitCenter;
             }
             if (sourcePos != Vector2.zero)
             {
-
                 GameObject gameObject = SpawnManager.SpawnProjectile(projectileToSpawn.gameObject, sourcePos, Quaternion.identity, true);
-                Projectile component = gameObject.GetComponent<Projectile>();
-                component.Owner = owner;
-                BeamController component2 = gameObject.GetComponent<BeamController>();
+                gameObject.GetComponent<Projectile>().Owner = owner;
+                BeamController beam = gameObject.GetComponent<BeamController>();
                 if (skipChargeTime)
                 {
-                    component2.chargeDelay = 0f;
-                    component2.usesChargeDelay = false;
+                    beam.chargeDelay = 0f;
+                    beam.usesChargeDelay = false;
                 }
-                component2.Owner = owner;
-                component2.HitsPlayers = false;
-                component2.HitsEnemies = true;
+                beam.Owner = owner;
+                beam.HitsPlayers = false;
+                beam.HitsEnemies = true;
                 Vector3 vector = BraveMathCollege.DegreesToVector(targetAngle, 1f);
-                if (otherShooter != null && otherShooter.GetComponent<Projectile>() && followDirOnProjectile) component2.Direction = (otherShooter.GetComponent<Projectile>().Direction.ToAngle() + angleOffsetFromProjectileAngle).DegreeToVector2();
-                else component2.Direction = vector;
-                component2.Origin = sourcePos;
-                GameManager.Instance.Dungeon.StartCoroutine(BeamAPI.HandleFreeFiringBeam(component2, rigidBod, fixedPosition, targetAngle, duration, followDirOnProjectile, angleOffsetFromProjectileAngle));
-                return component2;
+                if (otherShooter != null && otherShooter.GetComponent<Projectile>() && followDirOnProjectile)
+                    beam.Direction = (otherShooter.GetComponent<Projectile>().Direction.ToAngle() + angleOffsetFromProjectileAngle).DegreeToVector2();
+                else
+                    beam.Direction = vector;
+                beam.Origin = sourcePos;
+                GameManager.Instance.Dungeon.StartCoroutine(BeamAPI.HandleFreeFiringBeam(beam, rigidBod, fixedPosition, targetAngle, duration, followDirOnProjectile, angleOffsetFromProjectileAngle));
+                return beam;
             }
             else
             {
@@ -292,105 +273,81 @@ namespace Alexandria.ItemAPI
         private static IEnumerator HandleFreeFiringBeam(BeamController beam, SpeculativeRigidbody otherShooter, Vector2 fixedPosition, float targetAngle, float duration, bool followProjDir, float projFollowOffset)
         {
             bool parented = otherShooter != null;
-            float elapsed = 0f;
+            Projectile projToFollow = (followProjDir && otherShooter) ? otherShooter.GetComponent<Projectile>() : null;
+            Vector2 sourcePos = otherShooter ? otherShooter.UnitCenter : fixedPosition;
             yield return null;
-            while (elapsed < duration)
+            for (float elapsed = 0f; elapsed < duration; elapsed += BraveTime.DeltaTime)
             {
-                if (otherShooter == null && parented) { break; }
-                Vector2 sourcePos;
-                if (otherShooter == null) sourcePos = fixedPosition;
-                else sourcePos = otherShooter.UnitCenter;
-
-                elapsed += BraveTime.DeltaTime;
-                if (beam == null) { yield break; }
-                if (sourcePos != null)
+                if (!beam || (parented && !otherShooter))
+                    break;
+                if (otherShooter)
                 {
-                    if (otherShooter != null && otherShooter.GetComponent<Projectile>() && followProjDir)
-                    {
-                        beam.Direction = (otherShooter.GetComponent<Projectile>().Direction.ToAngle() + projFollowOffset).DegreeToVector2();
-                    }
+                    sourcePos = otherShooter.UnitCenter;
                     beam.Origin = sourcePos;
-                    beam.LateUpdatePosition(sourcePos);
                 }
-                else { ETGModConsole.Log("SOURCEPOS WAS NULL IN BEAM FIRING HANDLER"); }
+                if (projToFollow)
+                    beam.Direction = (projToFollow.Direction.ToAngle() + projFollowOffset).DegreeToVector2();
+                beam.LateUpdatePosition(sourcePos);
                 yield return null;
             }
-            if (beam){beam.CeaseAttack();}
+            if (beam)
+                beam.CeaseAttack();
             yield break;
         }
     }
+
     internal class EmmisiveBeams : MonoBehaviour
     {
-        public EmmisiveBeams()
-        {
-            this.EmissivePower = 100;
-            this.EmissiveColorPower = 1.55f;
-        }
         public void Start()
         {
-            Shader glowshader = ShaderCache.Acquire("Brave/LitTk2dCustomFalloffTiltedCutoutEmissive");
+            glowshader = ShaderCache.Acquire("Brave/LitTk2dCustomFalloffTiltedCutoutEmissive");
 
             foreach (Transform transform in base.transform)
             {
-                if (TransformList.Contains(transform.name))
-                {
-                    tk2dSprite sproot = transform.GetComponent<tk2dSprite>();
-                    if (sproot != null)
-                    {
-                        sproot.usesOverrideMaterial = true;
-                        sproot.renderer.material.shader = glowshader;
-                        sproot.renderer.material.EnableKeyword("BRIGHTNESS_CLAMP_ON");
-                        sproot.renderer.material.SetFloat("_EmissivePower", EmissivePower);
-                        sproot.renderer.material.SetFloat("_EmissiveColorPower", EmissiveColorPower);
-                    }
-                }
+                if (!TransformList.Contains(transform.name))
+                    continue;
+                if (transform.GetComponent<tk2dSprite>() is not tk2dSprite sproot)
+                    continue;
+
+                sproot.usesOverrideMaterial = true;
+                Material mat = sproot.renderer.material;
+                mat.shader = glowshader;
+                mat.EnableKeyword("BRIGHTNESS_CLAMP_ON");
+                mat.SetFloat("_EmissivePower", EmissivePower);
+                mat.SetFloat("_EmissiveColorPower", EmissiveColorPower);
             }
-            this.beamcont = base.GetComponent<BasicBeamController>();
-            BasicBeamController beam = this.beamcont;
-            beam.sprite.usesOverrideMaterial = true;
-            BasicBeamController component = beam.gameObject.GetComponent<BasicBeamController>();
-            bool flag = component != null;
-            bool flag2 = flag;
-            if (flag2)
-            {
-                component.sprite.renderer.material.shader = glowshader;
-                component.sprite.renderer.material.EnableKeyword("BRIGHTNESS_CLAMP_ON");
-                component.sprite.renderer.material.SetFloat("_EmissivePower", EmissivePower);
-                component.sprite.renderer.material.SetFloat("_EmissiveColorPower", EmissiveColorPower);
-            }
+            BasicBeamController cont = base.GetComponent<BasicBeamController>();
+            Material mat2 = cont.sprite.renderer.material;
+            mat2.shader = glowshader;
+            mat2.EnableKeyword("BRIGHTNESS_CLAMP_ON");
+            mat2.SetFloat("_EmissivePower", EmissivePower);
+            mat2.SetFloat("_EmissiveColorPower", EmissiveColorPower);
         }
 
+        public void Update()
+        {
+            if (base.transform.Find("beam pierce impact vfx") is not Transform t)
+                return;
+            if (t.GetComponent<tk2dSprite>() is not tk2dSprite sproot)
+                return;
 
-        private List<string> TransformList = new List<string>()
+            Material mat = sproot.renderer.material;
+            mat.shader = glowshader;
+            mat.EnableKeyword("BRIGHTNESS_CLAMP_ON");
+            mat.SetFloat("_EmissivePower", EmissivePower);
+            mat.SetFloat("_EmissiveColorPower", EmissiveColorPower);
+        }
+
+        private static List<string> TransformList = new List<string>()
         {
             "Sprite",
             "beam impact vfx 2",
             "beam impact vfx",
         };
 
-
-        public void Update()
-        {
-
-            Shader glowshader = ShaderCache.Acquire("Brave/LitTk2dCustomFalloffTiltedCutoutEmissive");
-            Transform trna = base.transform.Find("beam pierce impact vfx");
-            if (trna != null)
-            {
-                tk2dSprite sproot = trna.GetComponent<tk2dSprite>();
-                if (sproot != null)
-                {
-                    sproot.renderer.material.shader = glowshader;
-                    sproot.renderer.material.EnableKeyword("BRIGHTNESS_CLAMP_ON");
-                    sproot.renderer.material.SetFloat("_EmissivePower", EmissivePower);
-                    sproot.renderer.material.SetFloat("_EmissiveColorPower", EmissiveColorPower);
-                }
-            }
-
-        }
-
-        private BasicBeamController beamcont;
-        public float EmissivePower;
-        public float EmissiveColorPower;
+        private Shader glowshader;
+        public float EmissivePower = 100;
+        public float EmissiveColorPower = 1.55f;
     }
 }
 

--- a/ItemAPI/BeamAPI.cs
+++ b/ItemAPI/BeamAPI.cs
@@ -129,10 +129,7 @@ namespace Alexandria.ItemAPI
 
                 tiledSprite.SetSprite(ETGMod.Databases.Items.ProjectileCollection, spriteID);
                 tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
-                def.colliderVertices = new Vector3[]{
-                    0.0625f * colliderOffsets,
-                    0.0625f * colliderDimensions
-                };
+                def.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets, 0.0625f * colliderDimensions };
 
                 def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft); //NOTE: this seems right, but double check later
 
@@ -270,6 +267,7 @@ namespace Alexandria.ItemAPI
                 return null;
             }
         }
+
         private static IEnumerator HandleFreeFiringBeam(BeamController beam, SpeculativeRigidbody otherShooter, Vector2 fixedPosition, float targetAngle, float duration, bool followProjDir, float projFollowOffset)
         {
             bool parented = otherShooter != null;

--- a/ItemAPI/GunTools.cs
+++ b/ItemAPI/GunTools.cs
@@ -421,56 +421,7 @@ namespace Alexandria.ItemAPI
         }
         public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
-            if (!scale.HasValue)
-            {
-                scale = new Vector2?(def.position3);
-            }
-            if (fixesScale)
-            {
-                Vector2 fixedScale = scale.Value - def.position0.XY();
-                scale = new Vector2?(fixedScale);
-            }
-            float xOffset = 0;
-            if (anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.UpperCenter)
-            {
-                xOffset = -(scale.Value.x / 2f);
-            }
-            else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
-            {
-                xOffset = -scale.Value.x;
-            }
-            float yOffset = 0;
-            if (anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.MiddleLeft)
-            {
-                yOffset = -(scale.Value.y / 2f);
-            }
-            else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
-            {
-                yOffset = -scale.Value.y;
-            }
-            def.MakeOffset(new Vector2(xOffset, yOffset), false);
-            if (changesCollider && def.colliderVertices != null && def.colliderVertices.Length > 0)
-            {
-                float colliderXOffset = 0;
-                if (anchor == tk2dBaseSprite.Anchor.LowerLeft || anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.UpperLeft)
-                {
-                    colliderXOffset = (scale.Value.x / 2f);
-                }
-                else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
-                {
-                    colliderXOffset = -(scale.Value.x / 2f);
-                }
-                float colliderYOffset = 0;
-                if (anchor == tk2dBaseSprite.Anchor.LowerLeft || anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.LowerRight)
-                {
-                    colliderYOffset = (scale.Value.y / 2f);
-                }
-                else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
-                {
-                    colliderYOffset = -(scale.Value.y / 2f);
-                }
-                def.colliderVertices[0] += new Vector3(colliderXOffset, colliderYOffset, 0);
-            }
+            SharedExtensions.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
         }
         public static void SetFields(this Component comp, Component other, bool includeFields = true, bool includeProperties = true)
         {

--- a/ItemAPI/GunTools.cs
+++ b/ItemAPI/GunTools.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
+using Alexandria.Misc;
 
 namespace Alexandria.ItemAPI
 {
@@ -137,20 +138,7 @@ namespace Alexandria.ItemAPI
         }
         public static void AddOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            float xOffset = offset.x;
-            float yOffset = offset.y;
-            def.position0 += new Vector3(xOffset, yOffset, 0);
-            def.position1 += new Vector3(xOffset, yOffset, 0);
-            def.position2 += new Vector3(xOffset, yOffset, 0);
-            def.position3 += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            // def.boundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            // def.untrimmedBoundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            if (def.colliderVertices != null && def.colliderVertices.Length > 0 && changesCollider)
-            {
-                def.colliderVertices[0] += new Vector3(xOffset, yOffset, 0);
-            }
+            SharedExtensions.MakeOffset(def, offset, changesCollider);
         }
 
         public static IntVector2 TrimTexture(this Texture2D orig)
@@ -429,20 +417,7 @@ namespace Alexandria.ItemAPI
         }
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            float xOffset = offset.x;
-            float yOffset = offset.y;
-            def.position0 += new Vector3(xOffset, yOffset, 0);
-            def.position1 += new Vector3(xOffset, yOffset, 0);
-            def.position2 += new Vector3(xOffset, yOffset, 0);
-            def.position3 += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.boundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataCenter += new Vector3(xOffset, yOffset, 0);
-            def.untrimmedBoundsDataExtents += new Vector3(xOffset, yOffset, 0);
-            if (def.colliderVertices != null && def.colliderVertices.Length > 0 && changesCollider)
-            {
-                def.colliderVertices[0] += new Vector3(xOffset, yOffset, 0);
-            }
+            SharedExtensions.MakeOffset(def, offset, changesCollider);
         }
         public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {

--- a/ItemAPI/GunTools.cs
+++ b/ItemAPI/GunTools.cs
@@ -325,57 +325,14 @@ namespace Alexandria.ItemAPI
             result.colliderVertices = colliderVertices.ToArray();
             return result;
         }
+
         public static tk2dSpriteDefinition SetupDefinitionForProjectileSprite(string name, int id, int pixelWidth, int pixelHeight, bool lightened = true, int? overrideColliderPixelWidth = null, int? overrideColliderPixelHeight = null,
             int? overrideColliderOffsetX = null, int? overrideColliderOffsetY = null, Projectile overrideProjectileToCopyFrom = null)
         {
-            if (overrideColliderPixelWidth == null)
-            {
-                overrideColliderPixelWidth = pixelWidth;
-            }
-            if (overrideColliderPixelHeight == null)
-            {
-                overrideColliderPixelHeight = pixelHeight;
-            }
-            if (overrideColliderOffsetX == null)
-            {
-                overrideColliderOffsetX = 0;
-            }
-            if (overrideColliderOffsetY == null)
-            {
-                overrideColliderOffsetY = 0;
-            }
-            float thing = 16;
-            float thing2 = 16;
-            float trueWidth = (float)pixelWidth / thing;
-            float trueHeight = (float)pixelHeight / thing;
-            float colliderWidth = (float)overrideColliderPixelWidth.Value / thing2;
-            float colliderHeight = (float)overrideColliderPixelHeight.Value / thing2;
-            float colliderOffsetX = (float)overrideColliderOffsetX.Value / thing2;
-            float colliderOffsetY = (float)overrideColliderOffsetY.Value / thing2;
-            tk2dSpriteDefinition def = ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[(overrideProjectileToCopyFrom ??
-                    (PickupObjectDatabase.GetById(lightened ? 47 : 12) as Gun).DefaultModule.projectiles[0]).GetAnySprite().spriteId].CopyDefinitionFrom();
-            def.boundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
-            def.boundsDataExtents = new Vector3(trueWidth, trueHeight, 0f);
-            def.untrimmedBoundsDataCenter = new Vector3(trueWidth / 2f, trueHeight / 2f, 0f);
-            def.untrimmedBoundsDataExtents = new Vector3(trueWidth, trueHeight, 0f);
-            def.texelSize = new Vector2(1 / 16f, 1 / 16f);
-            def.position0 = new Vector3(0f, 0f, 0f);
-            def.position1 = new Vector3(0f + trueWidth, 0f, 0f);
-            def.position2 = new Vector3(0f, 0f + trueHeight, 0f);
-            def.position3 = new Vector3(0f + trueWidth, 0f + trueHeight, 0f);
-            def.colliderVertices = new Vector3[2];
-            def.colliderVertices[0] = new Vector3(colliderOffsetX, colliderOffsetY, 0f);
-            def.colliderVertices[1] = new Vector3(colliderWidth / 2, colliderHeight / 2);
-            def.name = name;
-
-            def.materialInst.mainTexture = ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[id].materialInst.mainTexture;
-            def.uvs = ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[id].uvs.ToArray();
-
-            ETGMod.Databases.Items.ProjectileCollection.inst.spriteDefinitions[id] = def;
-
-            return def;
+            var data = ETGMod.Databases.Items.ProjectileCollection.inst;
+            return Shared.SetupDefinitionForProjectileSprite(name, id, data, pixelWidth, pixelHeight, lightened, overrideColliderPixelWidth,
+                overrideColliderPixelHeight, overrideColliderOffsetX, overrideColliderOffsetY, overrideProjectileToCopyFrom);
         }
-
 
         /// <summary>
         /// Adds a custom sprite to your projectile from your mods sprites/ProjectileCollection folder.
@@ -402,9 +359,9 @@ namespace Alexandria.ItemAPI
                 tk2dSpriteDefinition def = SetupDefinitionForProjectileSprite(name, proj.GetAnySprite().spriteId, pixelWidth, pixelHeight, lightened, overrideColliderPixelWidth, overrideColliderPixelHeight, overrideColliderOffsetX,
                     overrideColliderOffsetY, overrideProjectileToCopyFrom);
                 def.ConstructOffsetsFromAnchor(anchor, def.position3, fixesScale, anchorChangesCollider);
-                proj.GetAnySprite().scale = new Vector3(1f, 1f, 1f);
-                proj.transform.localScale = new Vector3(1f, 1f, 1f);
-                proj.GetAnySprite().transform.localScale = new Vector3(1f, 1f, 1f);
+                proj.GetAnySprite().scale = Vector3.one;
+                proj.transform.localScale = Vector3.one;
+                proj.GetAnySprite().transform.localScale = Vector3.one;
                 proj.AdditionalScaleMultiplier = 1f;
                 return def;
             }
@@ -469,12 +426,7 @@ namespace Alexandria.ItemAPI
         /// <param name="gun">The gun being checked.</param>
         public static bool IsCurrentGun(this Gun gun)
         {
-            if (gun && gun.CurrentOwner)
-            {
-                if (gun.CurrentOwner.CurrentGun == gun) return true;
-                else return false;
-            }
-            else return false;
+            return gun && gun.CurrentOwner && (gun.CurrentOwner.CurrentGun == gun);
         }
 
         /// <summary>
@@ -483,8 +435,7 @@ namespace Alexandria.ItemAPI
         /// <param name="gun">The gun being checked for an owner.</param>
         public static PlayerController GunPlayerOwner(this Gun gun)
         {
-            if (gun && gun.CurrentOwner && gun.CurrentOwner is PlayerController) return gun.CurrentOwner as PlayerController;
-            else return null;
+            return gun ? (gun.CurrentOwner as PlayerController) : null;
         }
 
         public static ProjectileModule AddProjectileModuleToRawVolley(this Gun gun, ProjectileModule projectile)

--- a/ItemAPI/GunTools.cs
+++ b/ItemAPI/GunTools.cs
@@ -138,7 +138,7 @@ namespace Alexandria.ItemAPI
         }
         public static void AddOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            SharedExtensions.MakeOffset(def, offset, changesCollider);
+            Shared.MakeOffset(def, offset, changesCollider);
         }
 
         public static IntVector2 TrimTexture(this Texture2D orig)
@@ -417,11 +417,11 @@ namespace Alexandria.ItemAPI
         }
         public static void MakeOffset(this tk2dSpriteDefinition def, Vector2 offset, bool changesCollider = false)
         {
-            SharedExtensions.MakeOffset(def, offset, changesCollider);
+            Shared.MakeOffset(def, offset, changesCollider);
         }
         public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
-            SharedExtensions.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
+            Shared.ConstructOffsetsFromAnchor(def, anchor, scale, fixesScale, changesCollider);
         }
         public static void SetFields(this Component comp, Component other, bool includeFields = true, bool includeProperties = true)
         {

--- a/ItemAPI/SpriteTools/CustomClipAmmoTypeToolbox.cs
+++ b/ItemAPI/SpriteTools/CustomClipAmmoTypeToolbox.cs
@@ -11,6 +11,10 @@ namespace Alexandria.ItemAPI
     public static class CustomClipAmmoTypeToolbox
     {
         public static List<GameUIAmmoType> addedAmmoTypes = new List<GameUIAmmoType>();
+
+        [ObsoleteAttribute("This method is obsolete and does nothing; it exists for backwards compatability only.", false)]
+        public static void Init() { }
+
         public static string AddCustomAmmoType(string name, string ammoTypeSpritePath, string ammoBackgroundSpritePath)
         {
             Texture2D fgTexture = ResourceExtractor.GetTextureFromResource(ammoTypeSpritePath + ".png", Assembly.GetCallingAssembly());

--- a/ItemAPI/SpriteTools/SpriteBuilder.cs
+++ b/ItemAPI/SpriteTools/SpriteBuilder.cs
@@ -16,38 +16,18 @@ namespace Alexandria.ItemAPI
 		public static tk2dSpriteAnimationClip AddAnimation(tk2dSpriteAnimator animator, tk2dSpriteCollectionData collection, List<int> spriteIDs,
 			string clipName, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop, float fps = 15)
 		{
+			var clip = Shared.CreateAnimation(collection, spriteIDs, clipName, wrapMode, fps);
+
 			if (animator.Library == null)
 			{
 				animator.Library = animator.gameObject.AddComponent<tk2dSpriteAnimation>();
 				animator.Library.clips = new tk2dSpriteAnimationClip[0];
 				animator.Library.enabled = true;
-
 			}
 
-			List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-			for (int i = 0; i < spriteIDs.Count; i++)
-			{
-				tk2dSpriteDefinition sprite = collection.spriteDefinitions[spriteIDs[i]];
-				if (sprite.Valid)
-				{
-					frames.Add(new tk2dSpriteAnimationFrame()
-					{
-						spriteCollection = collection,
-						spriteId = spriteIDs[i]
-					});
-				}
-			}
-
-			var clip = new tk2dSpriteAnimationClip()
-			{
-				name = clipName,
-				fps = fps,
-				wrapMode = wrapMode,
-			};
 			Array.Resize(ref animator.Library.clips, animator.Library.clips.Length + 1);
 			animator.Library.clips[animator.Library.clips.Length - 1] = clip;
 
-			clip.frames = frames.ToArray();
 			return clip;
 		}
 		
@@ -214,73 +194,28 @@ namespace Alexandria.ItemAPI
 		public static tk2dSpriteAnimationClip AddAnimation(tk2dSpriteAnimation animaton, tk2dSpriteCollectionData collection, List<int> spriteIDs,
 			string clipName, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop, float fps = 15)
 		{
-			List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-			for (int i = 0; i < spriteIDs.Count; i++)
-			{
-				tk2dSpriteDefinition sprite = collection.spriteDefinitions[spriteIDs[i]];
-				if (sprite.Valid)
-				{
-					frames.Add(new tk2dSpriteAnimationFrame()
-					{
-						spriteCollection = collection,
-						spriteId = spriteIDs[i]
-					});
-				}
-			}
-			var clip = new tk2dSpriteAnimationClip()
-			{
-				name = clipName,
-				fps = fps,
-				wrapMode = wrapMode,
-			};
+			var clip = Shared.CreateAnimation(collection, spriteIDs, clipName, wrapMode, fps);
+
 			Array.Resize(ref animaton.clips, animaton.clips.Length + 1);
 			animaton.clips[animaton.clips.Length - 1] = clip;
-
-			clip.frames = frames.ToArray();
 			return clip;
 		}
 
 		public static tk2dSpriteAnimationClip AddAnimation(tk2dSpriteAnimator animator, tk2dSpriteCollectionData collection, List<string> spritePaths,
 	string clipName, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop, int fps = 15)
 		{
+			var clip = Assembly.GetCallingAssembly().CreateAnimation(collection, spritePaths, clipName, wrapMode, fps);
+
 			if (animator.Library == null)
 			{
 				animator.Library = animator.gameObject.AddComponent<tk2dSpriteAnimation>();
 				animator.Library.clips = new tk2dSpriteAnimationClip[0];
 				animator.Library.enabled = true;
-
-			}
-			List<int> spriteIDs = new List<int>();
-
-			foreach(var FUCKINGDIE in spritePaths)
-            {
-				spriteIDs.Add(AddSpriteToCollection(FUCKINGDIE, collection, Assembly.GetCallingAssembly()));
 			}
 
-			List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-			for (int i = 0; i < spriteIDs.Count; i++)
-			{
-				tk2dSpriteDefinition sprite = collection.spriteDefinitions[spriteIDs[i]];
-				if (sprite.Valid)
-				{
-					frames.Add(new tk2dSpriteAnimationFrame()
-					{
-						spriteCollection = collection,
-						spriteId = spriteIDs[i]
-					});
-				}
-			}
-
-			var clip = new tk2dSpriteAnimationClip()
-			{
-				name = clipName,
-				fps = fps,
-				wrapMode = wrapMode,
-			};
 			Array.Resize(ref animator.Library.clips, animator.Library.clips.Length + 1);
 			animator.Library.clips[animator.Library.clips.Length - 1] = clip;
 
-			clip.frames = frames.ToArray();
 			return clip;
 		}
 
@@ -305,12 +240,12 @@ namespace Alexandria.ItemAPI
 		// Token: 0x06000009 RID: 9 RVA: 0x00002404 File Offset: 0x00000604
 		public static tk2dSpriteDefinition ConstructDefinition(Texture2D texture)
 		{
-			return SharedExtensions.ConstructDefinition(texture: texture, overrideMat: null, apply: false, useOffset: false);
+			return Shared.ConstructDefinition(texture: texture, overrideMat: null, apply: false, useOffset: false);
 		}
 
 		public static tk2dSpriteDefinition ConstructDefinition2(Texture2D texture, tk2dSpriteCollectionData collection)
 		{
-			return SharedExtensions.ConstructDefinition(texture: texture, overrideMat: null, apply: false, useOffset: true);
+			return Shared.ConstructDefinition(texture: texture, overrideMat: null, apply: false, useOffset: true);
 		}
 
 		// Token: 0x0600000A RID: 10 RVA: 0x000026EC File Offset: 0x000008EC

--- a/ItemAPI/SpriteTools/SpriteBuilder.cs
+++ b/ItemAPI/SpriteTools/SpriteBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Alexandria.DungeonAPI;
+using Alexandria.Misc;
 using UnityEngine;
 
 namespace Alexandria.ItemAPI
@@ -304,127 +305,12 @@ namespace Alexandria.ItemAPI
 		// Token: 0x06000009 RID: 9 RVA: 0x00002404 File Offset: 0x00000604
 		public static tk2dSpriteDefinition ConstructDefinition(Texture2D texture)
 		{
-			RuntimeAtlasSegment runtimeAtlasSegment = ETGMod.Assets.Packer.Pack(texture, false);
-			Material material = new Material(ShaderCache.Acquire(PlayerController.DefaultShaderName));
-			material.mainTexture = runtimeAtlasSegment.texture;
-			int width = texture.width;
-			int height = texture.height;
-			float num = 0f;
-			float num2 = 0f;
-			float num3 = (float)width / 16f;
-			float num4 = (float)height / 16f;
-			tk2dSpriteDefinition tk2dSpriteDefinition = new tk2dSpriteDefinition
-			{
-				normals = new Vector3[]
-				{
-					new Vector3(0f, 0f, -1f),
-					new Vector3(0f, 0f, -1f),
-					new Vector3(0f, 0f, -1f),
-					new Vector3(0f, 0f, -1f)
-				},
-				tangents = new Vector4[]
-				{
-					new Vector4(1f, 0f, 0f, 1f),
-					new Vector4(1f, 0f, 0f, 1f),
-					new Vector4(1f, 0f, 0f, 1f),
-					new Vector4(1f, 0f, 0f, 1f)
-				},
-				texelSize = new Vector2(0.0625f, 0.0625f),
-				extractRegion = false,
-				regionX = 0,
-				regionY = 0,
-				regionW = 0,
-				regionH = 0,
-				flipped = tk2dSpriteDefinition.FlipMode.None,
-				complexGeometry = false,
-				physicsEngine = tk2dSpriteDefinition.PhysicsEngine.Physics3D,
-				colliderType = tk2dSpriteDefinition.ColliderType.None,
-				collisionLayer = CollisionLayer.HighObstacle,
-				position0 = new Vector3(num, num2, 0f),
-				position1 = new Vector3(num + num3, num2, 0f),
-				position2 = new Vector3(num, num2 + num4, 0f),
-				position3 = new Vector3(num + num3, num2 + num4, 0f),
-				material = material,
-				materialInst = material,
-				materialId = 0,
-				uvs = runtimeAtlasSegment.uvs,
-				boundsDataCenter = new Vector3(num3 / 2f, num4 / 2f, 0f),
-				boundsDataExtents = new Vector3(num3, num4, 0f),
-				untrimmedBoundsDataCenter = new Vector3(num3 / 2f, num4 / 2f, 0f),
-				untrimmedBoundsDataExtents = new Vector3(num3, num4, 0f)
-			};
-			tk2dSpriteDefinition.name = texture.name;
-			return tk2dSpriteDefinition;
+			return SharedExtensions.ConstructDefinition(texture: texture, overrideMat: null, apply: false, useOffset: false);
 		}
 
 		public static tk2dSpriteDefinition ConstructDefinition2(Texture2D texture, tk2dSpriteCollectionData collection)
 		{
-			RuntimeAtlasSegment runtimeAtlasSegment = ETGMod.Assets.Packer.Pack(texture, false);
-			Material material = new Material(ShaderCache.Acquire(PlayerController.DefaultShaderName));
-			material.mainTexture = runtimeAtlasSegment.texture;
-			float width = texture.width;
-			float height = texture.height;
-			float num3 = width / 16;
-			float num4 = height / 16f;
-
-
-			Vector2 anchor = tk2dSpriteGeomGen.GetAnchorOffset(tk2dBaseSprite.Anchor.LowerLeft, num3, num4);
-
-			float scale = 1;
-
-			Vector3 pos0 = new Vector3(0, -height * scale, 0.0f);
-			Vector3 pos1 = pos0 + new Vector3(num3 * scale, height * scale, 0.0f);
-
-			Rect trimRect = new Rect(0, 0, 0, 0);
-			trimRect.Set(0, 0, num3, num4);
-
-			Vector2 offset = new Vector2(trimRect.x - anchor.x, -trimRect.y + anchor.y);
-
-
-			tk2dSpriteDefinition tk2dSpriteDefinition = new tk2dSpriteDefinition
-			{
-				normals = new Vector3[]
-				{
-					new Vector3(0f, 0f, -1f),
-					new Vector3(0f, 0f, -1f),
-					new Vector3(0f, 0f, -1f),
-					new Vector3(0f, 0f, -1f)
-				},
-				tangents = new Vector4[]
-				{
-					new Vector4(1f, 0f, 0f, 1f),
-					new Vector4(1f, 0f, 0f, 1f),
-					new Vector4(1f, 0f, 0f, 1f),
-					new Vector4(1f, 0f, 0f, 1f)
-				},
-				texelSize = new Vector2(0.0625f, 0.0625f),
-				extractRegion = false,
-				regionX = 0,
-				regionY = 0,
-				regionW = 0,
-				regionH = 0,
-				flipped = tk2dSpriteDefinition.FlipMode.None,
-				complexGeometry = false,
-				physicsEngine = tk2dSpriteDefinition.PhysicsEngine.Physics3D,
-				colliderType = tk2dSpriteDefinition.ColliderType.None,
-				collisionLayer = CollisionLayer.HighObstacle,
-
-				position0 = new Vector3(pos0.x + offset.x, pos0.y + offset.y, 0),
-				position1 = new Vector3(pos1.x + offset.x, pos0.y + offset.y, 0),
-				position2 = new Vector3(pos0.x + offset.x, pos1.y + offset.y, 0),
-				position3 = new Vector3(pos1.x + offset.x, pos1.y + offset.y, 0),
-
-				material = material,
-				materialInst = material,
-				materialId = 0,
-				uvs = runtimeAtlasSegment.uvs,
-				boundsDataCenter = new Vector3(num3 / 2f, num4 / 2f, 0f),
-				boundsDataExtents = new Vector3(num3, num4, 0f),
-				untrimmedBoundsDataCenter = new Vector3(num3 / 2f, num4 / 2f, 0f),
-				untrimmedBoundsDataExtents = new Vector3(num3, num4, 0f)
-			};
-			tk2dSpriteDefinition.name = texture.name;
-			return tk2dSpriteDefinition;
+			return SharedExtensions.ConstructDefinition(texture: texture, overrideMat: null, apply: false, useOffset: true);
 		}
 
 		// Token: 0x0600000A RID: 10 RVA: 0x000026EC File Offset: 0x000008EC

--- a/Misc/SharedExtensions.cs
+++ b/Misc/SharedExtensions.cs
@@ -22,8 +22,13 @@ namespace Alexandria.Misc
                 def.colliderVertices[0] += offset;
         }
 
+        private static readonly HashSet<tk2dSpriteDefinition> adjustedDefs = new();
         internal static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
         {
+            if (adjustedDefs.Contains(def))
+                return; // don't set up offsets for definitions multiple times
+            adjustedDefs.Add(def);
+
             if (!scale.HasValue)
             {
                 scale = new Vector2?(def.position3);
@@ -198,12 +203,13 @@ namespace Alexandria.Misc
 
         internal static void SetupBeamPart(tk2dSpriteAnimation beamAnimation, tk2dSpriteCollectionData data, string animationName, Vector2? colliderDimensions = null,
             Vector2? colliderOffsets = null, Vector3[] overrideVertices = null, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Once,
-            tk2dBaseSprite.Anchor anchor = tk2dBaseSprite.Anchor.MiddleLeft)
+            tk2dBaseSprite.Anchor anchor = tk2dBaseSprite.Anchor.MiddleLeft, bool constructOffsets = true)
         {
             foreach (var frame in beamAnimation.GetClipByName(animationName).frames)
             {
                 tk2dSpriteDefinition frameDef = data.spriteDefinitions[frame.spriteId];
-                frameDef.ConstructOffsetsFromAnchor(anchor);
+                if (constructOffsets)
+                    frameDef.ConstructOffsetsFromAnchor(anchor);
                 if (overrideVertices != null)
                     frameDef.colliderVertices = overrideVertices;
                 else if (colliderDimensions != null && colliderOffsets != null)
@@ -231,6 +237,133 @@ namespace Alexandria.Misc
             beamAnimation.clips = beamAnimation.clips.Concat(new tk2dSpriteAnimationClip[] { clip }).ToArray();
             SetupBeamPart(beamAnimation, collection, animationName, colliderDimensions, colliderOffsets, overrideVertices,
                 wrapMode: tk2dSpriteAnimationClip.WrapMode.Once, anchor: anchor);
+        }
+
+        internal static BasicBeamController GenerateBeamPrefabBundleInternal(this Projectile projectile, string defaultSpriteName, tk2dSpriteCollectionData data,
+            tk2dSpriteAnimation animation, string IdleAnimationName, Vector2 colliderDimensions, Vector2 colliderOffsets, string impactVFXAnimationName = null,
+            Vector2? impactVFXColliderDimensions = null, Vector2? impactVFXColliderOffsets = null, string endAnimation = null, Vector2? endColliderDimensions = null,
+            Vector2? endColliderOffsets = null, string muzzleAnimationName = null, Vector2? muzzleColliderDimensions = null, Vector2? muzzleColliderOffsets = null,
+            bool glows = false, bool canTelegraph = false, string beamTelegraphIdleAnimationName = null, string beamStartTelegraphAnimationName = null,
+            string beamEndTelegraphAnimationName = null, float telegraphTime = 1, bool canDissipate = false, string beamDissipateAnimationName = null,
+            string beamStartDissipateAnimationName = null, string beamEndDissipateAnimationName = null, float dissipateTime = 1, bool constructOffsets = true)
+        {
+            try
+            {
+                if (projectile.specRigidbody)
+                    projectile.specRigidbody.CollideWithOthers = false;
+
+                tk2dTiledSprite tiledSprite = projectile.gameObject.GetOrAddComponent<tk2dTiledSprite>();
+
+                tiledSprite.Collection = data;
+                tiledSprite.SetSprite(data, data.GetSpriteIdByName(defaultSpriteName));
+                tk2dSpriteDefinition def = tiledSprite.GetCurrentSpriteDef();
+                def.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets, 0.0625f * colliderDimensions };
+
+                def.ConstructOffsetsFromAnchor(tk2dBaseSprite.Anchor.MiddleLeft); //NOTE: this seems right, but double check later
+
+                tk2dSpriteAnimator animator = projectile.gameObject.GetOrAddComponent<tk2dSpriteAnimator>();
+                animator._startingSpriteCollection = data;
+                animator.Library = animation;
+                animator.playAutomatically = true;
+                animator.defaultClipId = animation.GetClipIdByName(IdleAnimationName);
+
+                UnityEngine.Object.Destroy(projectile.GetComponentInChildren<tk2dSprite>());
+                projectile.sprite = tiledSprite;
+                projectile.sprite.Collection = data;
+
+                BasicBeamController beamController = projectile.gameObject.GetOrAddComponent<BasicBeamController>();
+                beamController.sprite = tiledSprite;
+                beamController.spriteAnimator = animator;
+                beamController.m_beamSprite = tiledSprite;
+
+                //---------------- Sets up the animation for the main part of the beam
+                beamController.beamAnimation = IdleAnimationName;
+
+                //------------- Sets up the animation for the part of the beam that touches the wall
+
+                if (endAnimation != null && endColliderDimensions != null && endColliderOffsets != null)
+                {
+                    SetupBeamPart(animation, data, endAnimation, (Vector2)endColliderDimensions, (Vector2)endColliderOffsets, constructOffsets: constructOffsets);
+                    beamController.beamEndAnimation = endAnimation;
+                }
+                else
+                {
+                    SetupBeamPart(animation, data, IdleAnimationName, null, null, def.colliderVertices, constructOffsets: constructOffsets);
+                    beamController.beamEndAnimation = IdleAnimationName;
+                }
+
+                //---------------Sets up the animaton for the VFX that plays over top of the end of the beam where it hits stuff
+                if (impactVFXAnimationName != null && impactVFXColliderDimensions != null && impactVFXColliderOffsets != null)
+                {
+                    SetupBeamPart(animation, data, impactVFXAnimationName, (Vector2)impactVFXColliderDimensions, (Vector2)impactVFXColliderOffsets, anchor: tk2dBaseSprite.Anchor.MiddleCenter, constructOffsets: constructOffsets);
+                    beamController.impactAnimation = impactVFXAnimationName;
+                }
+
+                //--------------Sets up the animation for the very start of the beam
+                if (muzzleAnimationName != null && muzzleColliderDimensions != null && muzzleColliderOffsets != null)
+                {
+                    SetupBeamPart(animation, data, muzzleAnimationName, (Vector2)muzzleColliderDimensions, (Vector2)muzzleColliderOffsets, constructOffsets: constructOffsets);
+                    beamController.beamStartAnimation = muzzleAnimationName;
+                }
+                else
+                {
+                    SetupBeamPart(animation, data, IdleAnimationName, null, null, def.colliderVertices, constructOffsets: constructOffsets);
+                    beamController.beamStartAnimation = IdleAnimationName;
+                }
+
+                if (canTelegraph)
+                {
+                    beamController.usesTelegraph = true;
+                    beamController.telegraphAnimations = new BasicBeamController.TelegraphAnims();
+                    if (beamStartTelegraphAnimationName != null)
+                    {
+                        SetupBeamPart(animation, data, beamStartTelegraphAnimationName, Vector2.zero, Vector2.zero, constructOffsets: constructOffsets);
+                        beamController.telegraphAnimations.beamStartAnimation = beamStartTelegraphAnimationName;
+                    }
+                    if (beamTelegraphIdleAnimationName != null)
+                    {
+                        SetupBeamPart(animation, data, beamTelegraphIdleAnimationName, Vector2.zero, Vector2.zero, constructOffsets: constructOffsets);
+                        beamController.telegraphAnimations.beamAnimation = beamTelegraphIdleAnimationName;
+                    }
+                    if (beamEndTelegraphAnimationName != null)
+                    {
+                        SetupBeamPart(animation, data, beamEndTelegraphAnimationName, Vector2.zero, Vector2.zero, constructOffsets: constructOffsets);
+                        beamController.telegraphAnimations.beamEndAnimation = beamEndTelegraphAnimationName;
+                    }
+                    beamController.telegraphTime = telegraphTime;
+                }
+
+                if (canDissipate)
+                {
+                    beamController.endType = BasicBeamController.BeamEndType.Dissipate;
+                    beamController.dissipateAnimations = new BasicBeamController.TelegraphAnims();
+                    if (beamStartDissipateAnimationName != null)
+                    {
+                        SetupBeamPart(animation, data, beamStartDissipateAnimationName, Vector2.zero, Vector2.zero, constructOffsets: constructOffsets);
+                        beamController.dissipateAnimations.beamStartAnimation = beamStartDissipateAnimationName;
+                    }
+                    if (beamDissipateAnimationName != null)
+                    {
+                        SetupBeamPart(animation, data, beamDissipateAnimationName, Vector2.zero, Vector2.zero, constructOffsets: constructOffsets);
+                        beamController.dissipateAnimations.beamAnimation = beamDissipateAnimationName;
+                    }
+                    if (beamEndDissipateAnimationName != null)
+                    {
+                        SetupBeamPart(animation, data, beamEndDissipateAnimationName, Vector2.zero, Vector2.zero, constructOffsets: constructOffsets);
+                        beamController.dissipateAnimations.beamEndAnimation = beamEndDissipateAnimationName;
+                    }
+                    beamController.dissipateTime = dissipateTime;
+                }
+
+                if (glows)
+                    projectile.gameObject.GetOrAddComponent<EmmisiveBeams>();
+                return beamController;
+            }
+            catch (Exception e)
+            {
+                ETGModConsole.Log(e.ToString());
+                return null;
+            }
         }
     }
 }

--- a/Misc/SharedExtensions.cs
+++ b/Misc/SharedExtensions.cs
@@ -74,5 +74,89 @@ namespace Alexandria.Misc
                 def.colliderVertices[0] += new Vector3(colliderXOffset, colliderYOffset, 0);
             }
         }
+
+        public static tk2dSpriteDefinition ConstructDefinition(Texture2D texture, Material overrideMat = null, bool apply = true, bool useOffset = false)
+        {
+            RuntimeAtlasSegment ras = ETGMod.Assets.Packer.Pack(texture, apply); //pack your resources beforehand or the outlines will turn out weird
+
+            Material material = null;
+            if (overrideMat != null)
+            {
+                material = overrideMat;
+            }
+            else
+            {
+                material = new Material(ShaderCache.Acquire(PlayerController.DefaultShaderName));
+            }
+            material.mainTexture = ras.texture;
+
+            var width = texture.width;
+            var height = texture.height;
+
+            var x = 0f;
+            var y = 0f;
+
+            var w = width / 16f;
+            var h = height / 16f;
+
+            float posX, posY, posW, posH;
+            if (useOffset) //NOTE: I don't think the original code for this functions as intended, but I also can't find indication anyone uses it...
+            {
+                Vector2 anchor = tk2dSpriteGeomGen.GetAnchorOffset(tk2dBaseSprite.Anchor.LowerLeft, w, h);
+                posX = -anchor.x;
+                posY = -height + anchor.y; //NOTE: this doesn't seem right, but that's how it was originally...
+                posW = w;
+                posH = height; //NOTE: this doesn't seem right, but that's how it was originally...
+            }
+            else
+            {
+                posX = x;
+                posY = y;
+                posW = w;
+                posH = h;
+            }
+
+            var def = new tk2dSpriteDefinition
+            {
+                normals = new Vector3[] {
+                    new Vector3(0.0f, 0.0f, -1.0f),
+                    new Vector3(0.0f, 0.0f, -1.0f),
+                    new Vector3(0.0f, 0.0f, -1.0f),
+                    new Vector3(0.0f, 0.0f, -1.0f),
+                },
+                tangents = new Vector4[] {
+                    new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
+                    new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
+                    new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
+                    new Vector4(1.0f, 0.0f, 0.0f, 1.0f),
+                },
+                texelSize = new Vector2(1 / 16f, 1 / 16f),
+                extractRegion = false,
+                regionX = 0,
+                regionY = 0,
+                regionW = 0,
+                regionH = 0,
+                flipped = tk2dSpriteDefinition.FlipMode.None,
+                complexGeometry = false,
+                physicsEngine = tk2dSpriteDefinition.PhysicsEngine.Physics3D,
+                colliderType = tk2dSpriteDefinition.ColliderType.None,
+                collisionLayer = CollisionLayer.HighObstacle,
+                position0 = new Vector3(posX, posY, 0f),
+                position1 = new Vector3(posX + posW, posY, 0f),
+                position2 = new Vector3(posX, posY + posH, 0f),
+                position3 = new Vector3(posX + posW, posY + posH, 0f),
+                material = material,
+                materialInst = material,
+                materialId = 0,
+                uvs = ras.uvs,
+                boundsDataCenter = new Vector3(w / 2f, h / 2f, 0f),
+                boundsDataExtents = new Vector3(w, h, 0f),
+                untrimmedBoundsDataCenter = new Vector3(w / 2f, h / 2f, 0f),
+                untrimmedBoundsDataExtents = new Vector3(w, h, 0f),
+            };
+
+            def.name = texture.name;
+            return def;
+        }
     }
 }

--- a/Misc/SharedExtensions.cs
+++ b/Misc/SharedExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UnityEngine;
+
+namespace Alexandria.Misc
+{
+    public static class SharedExtensions
+    {
+        public static void MakeOffset(this tk2dSpriteDefinition def, Vector3 offset, bool changesCollider = false)
+        {
+            def.position0 += offset;
+            def.position1 += offset;
+            def.position2 += offset;
+            def.position3 += offset;
+            def.boundsDataCenter += offset;
+            def.untrimmedBoundsDataCenter += offset;
+            if (changesCollider && def.colliderVertices != null && def.colliderVertices.Length > 0)
+                def.colliderVertices[0] += offset;
+        }
+    }
+}

--- a/Misc/SharedExtensions.cs
+++ b/Misc/SharedExtensions.cs
@@ -207,7 +207,7 @@ namespace Alexandria.Misc
                 if (overrideVertices != null)
                     frameDef.colliderVertices = overrideVertices;
                 else if (colliderDimensions != null && colliderOffsets != null)
-                    frameDef.colliderVertices = new Vector3[]{ 0.0625f * colliderDimensions.Value, 0.0625f * colliderOffsets.Value };
+                    frameDef.colliderVertices = new Vector3[]{ 0.0625f * colliderOffsets.Value, 0.0625f * colliderDimensions.Value };
                 else
                     ETGModConsole.Log("<size=100><color=#ff0000ff>BEAM ERROR: colliderDimensions or colliderOffsets was null with no override vertices!</color></size>", false);
             }

--- a/Misc/SharedExtensions.cs
+++ b/Misc/SharedExtensions.cs
@@ -20,5 +20,59 @@ namespace Alexandria.Misc
             if (changesCollider && def.colliderVertices != null && def.colliderVertices.Length > 0)
                 def.colliderVertices[0] += offset;
         }
+
+        public static void ConstructOffsetsFromAnchor(this tk2dSpriteDefinition def, tk2dBaseSprite.Anchor anchor, Vector2? scale = null, bool fixesScale = false, bool changesCollider = true)
+        {
+            if (!scale.HasValue)
+            {
+                scale = new Vector2?(def.position3);
+            }
+            if (fixesScale)
+            {
+                Vector2 fixedScale = scale.Value - def.position0.XY();
+                scale = new Vector2?(fixedScale);
+            }
+            float xOffset = 0;
+            if (anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.UpperCenter)
+            {
+                xOffset = -(scale.Value.x / 2f);
+            }
+            else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
+            {
+                xOffset = -scale.Value.x;
+            }
+            float yOffset = 0;
+            if (anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.MiddleCenter || anchor == tk2dBaseSprite.Anchor.MiddleLeft)
+            {
+                yOffset = -(scale.Value.y / 2f);
+            }
+            else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
+            {
+                yOffset = -scale.Value.y;
+            }
+            def.MakeOffset(new Vector2(xOffset, yOffset), false);
+            if (changesCollider && def.colliderVertices != null && def.colliderVertices.Length > 0)
+            {
+                float colliderXOffset = 0;
+                if (anchor == tk2dBaseSprite.Anchor.LowerLeft || anchor == tk2dBaseSprite.Anchor.MiddleLeft || anchor == tk2dBaseSprite.Anchor.UpperLeft)
+                {
+                    colliderXOffset = (scale.Value.x / 2f);
+                }
+                else if (anchor == tk2dBaseSprite.Anchor.LowerRight || anchor == tk2dBaseSprite.Anchor.MiddleRight || anchor == tk2dBaseSprite.Anchor.UpperRight)
+                {
+                    colliderXOffset = -(scale.Value.x / 2f);
+                }
+                float colliderYOffset = 0;
+                if (anchor == tk2dBaseSprite.Anchor.LowerLeft || anchor == tk2dBaseSprite.Anchor.LowerCenter || anchor == tk2dBaseSprite.Anchor.LowerRight)
+                {
+                    colliderYOffset = (scale.Value.y / 2f);
+                }
+                else if (anchor == tk2dBaseSprite.Anchor.UpperLeft || anchor == tk2dBaseSprite.Anchor.UpperCenter || anchor == tk2dBaseSprite.Anchor.UpperRight)
+                {
+                    colliderYOffset = -(scale.Value.y / 2f);
+                }
+                def.colliderVertices[0] += new Vector3(colliderXOffset, colliderYOffset, 0);
+            }
+        }
     }
 }

--- a/Module.cs
+++ b/Module.cs
@@ -30,7 +30,7 @@ namespace Alexandria
         public const string GUID = "alexandria.etgmod.alexandria";
         public const string NAME = "Alexandria";
 
-        public const string VERSION = "0.4.8";
+        public const string VERSION = "0.4.9";
 
 
 

--- a/NPCAPI/ShopAPI.cs
+++ b/NPCAPI/ShopAPI.cs
@@ -3,6 +3,7 @@ using Alexandria.DungeonAPI;
 using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using Alexandria.ItemAPI;
+using Alexandria.Misc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1814,38 +1815,18 @@ namespace Alexandria.NPCAPI
         public static tk2dSpriteAnimationClip AddAnimation(tk2dSpriteAnimator animator, tk2dSpriteCollectionData collection, List<int> spriteIDs,
             string clipName, tk2dSpriteAnimationClip.WrapMode wrapMode = tk2dSpriteAnimationClip.WrapMode.Loop, float fps = 15)
         {
+            var clip = Shared.CreateAnimation(collection, spriteIDs, clipName, wrapMode, fps);
+
             if (animator.Library == null)
             {
                 animator.Library = animator.gameObject.AddComponent<tk2dSpriteAnimation>();
                 animator.Library.clips = new tk2dSpriteAnimationClip[0];
                 animator.Library.enabled = true;
-
             }
 
-            List<tk2dSpriteAnimationFrame> frames = new List<tk2dSpriteAnimationFrame>();
-            for (int i = 0; i < spriteIDs.Count; i++)
-            {
-                tk2dSpriteDefinition sprite = collection.spriteDefinitions[spriteIDs[i]];
-                if (sprite.Valid)
-                {
-                    frames.Add(new tk2dSpriteAnimationFrame()
-                    {
-                        spriteCollection = collection,
-                        spriteId = spriteIDs[i]
-                    });
-                }
-            }
-
-            var clip = new tk2dSpriteAnimationClip()
-            {
-                name = clipName,
-                fps = fps,
-                wrapMode = wrapMode,
-            };
             Array.Resize(ref animator.Library.clips, animator.Library.clips.Length + 1);
             animator.Library.clips[animator.Library.clips.Length - 1] = clip;
 
-            clip.frames = frames.ToArray();
             return clip;
         }
 

--- a/cAPI/HatUtility.cs
+++ b/cAPI/HatUtility.cs
@@ -7,6 +7,7 @@ using Gungeon;
 using Dungeonator;
 using System.Reflection;
 using Alexandria.ItemAPI;
+using Alexandria.Misc;
 using System.Collections;
 using System.Globalization;
 using System.IO;
@@ -280,14 +281,7 @@ namespace Alexandria.cAPI
 
         private static void AdjustOffset(this tk2dSpriteDefinition def, Vector3 offset)
         {
-            def.position0 += offset;
-            def.position1 += offset;
-            def.position2 += offset;
-            def.position3 += offset;
-            def.boundsDataCenter += offset;
-            def.boundsDataExtents += offset;
-            def.untrimmedBoundsDataCenter += offset;
-            def.untrimmedBoundsDataExtents += offset;
+            SharedExtensions.MakeOffset(def, offset);
         }
 
         private static void AddHatToDatabase(Hat hat, bool excludeFromHatRoom)

--- a/cAPI/HatUtility.cs
+++ b/cAPI/HatUtility.cs
@@ -273,15 +273,10 @@ namespace Alexandria.cAPI
                 int frameSpriteId = SpriteBuilder.AddSpriteToCollection(path, HatSpriteCollection, callingASM);
                 tk2dSpriteDefinition frameDef = HatSpriteCollection.spriteDefinitions[frameSpriteId];
                 frameDef.colliderVertices = def.colliderVertices;
-                frameDef.AdjustOffset(offset);
+                Shared.MakeOffset(frameDef, offset);
                 clip.frames[i] = new tk2dSpriteAnimationFrame { spriteId = frameSpriteId, spriteCollection = HatSpriteCollection };
             }
             animation.clips = animation.clips.Concat(new tk2dSpriteAnimationClip[] { clip }).ToArray();
-        }
-
-        private static void AdjustOffset(this tk2dSpriteDefinition def, Vector3 offset)
-        {
-            Shared.MakeOffset(def, offset);
         }
 
         private static void AddHatToDatabase(Hat hat, bool excludeFromHatRoom)

--- a/cAPI/HatUtility.cs
+++ b/cAPI/HatUtility.cs
@@ -281,7 +281,7 @@ namespace Alexandria.cAPI
 
         private static void AdjustOffset(this tk2dSpriteDefinition def, Vector3 offset)
         {
-            SharedExtensions.MakeOffset(def, offset);
+            Shared.MakeOffset(def, offset);
         }
 
         private static void AddHatToDatabase(Hat hat, bool excludeFromHatRoom)


### PR DESCRIPTION
- Unified all variants of MakeOffset() and fixed a bug with adjusting boundsDataExtents unnecessarily
- Unified all variants of ConstructOffsetsFromAnchor()
- Unified all variants of ConstructDefinition()
- Unified several variants of AddAnimation()
- Unified all variants of SetupBeamPart()
- Unified both variants of SetupDefinitionForProjectileSprite()
- Reinstated CustomClipAmmoTypeToolbox.Init() as a stub and marked as obsolete
- Cleaned up ProjectileBuilders.cs, BeamBuilders.cs, and BeamAPI.cs
- Added GenerateAnchoredBeamPrefabBundle() for setting up beams for sprites with predefined anchors
- Updated version to 0.4.9