### PR TITLE
0.4.13 - Bugfixes

### DIFF
--- a/ItemAPI/SpriteTools/SpriteBuilder.cs
+++ b/ItemAPI/SpriteTools/SpriteBuilder.cs
@@ -223,6 +223,7 @@ namespace Alexandria.ItemAPI
 		public static SpeculativeRigidbody SetUpSpeculativeRigidbody(this tk2dSprite sprite, IntVector2 offset, IntVector2 dimensions)
 		{
 			SpeculativeRigidbody body = sprite.gameObject.GetOrAddComponent<SpeculativeRigidbody>();
+			body.PixelColliders = new();
 			body.AddCollider(CollisionLayer.EnemyCollider, offset, dimensions);
 			return body;
 		}

--- a/Misc/CustomAmmoDisplay.cs
+++ b/Misc/CustomAmmoDisplay.cs
@@ -21,7 +21,8 @@ namespace Alexandria.Misc
               return false; // custom ammo override does not want to change vanilla behavior
 
             // we're definitely using the custom ammo display, so prepare it
-            uic.GunAmmoCountLabel.AutoSize = true; // enable dynamic width
+            if (uic.GunAmmoCountLabel.Size.x < 1000)
+              uic.GunAmmoCountLabel.Size = uic.GunAmmoCountLabel.Size.WithX(1000f); // uncap width so long labels can display
             uic.GunAmmoCountLabel.AutoHeight = true; // enable multiline text
             uic.GunAmmoCountLabel.ProcessMarkup = true; // enable multicolor text
 

--- a/Module.cs
+++ b/Module.cs
@@ -30,7 +30,7 @@ namespace Alexandria
         public const string GUID = "alexandria.etgmod.alexandria";
         public const string NAME = "Alexandria";
 
-        public const string VERSION = "0.4.12";
+        public const string VERSION = "0.4.13";
 
 
 


### PR DESCRIPTION
- Fix issue with vanilla ammo labels shifting offscreen when displaying certain custom ammo labels
- Fix faulty refactor where `SetUpSpeculativeRigidbody()` didn't properly clear existing pixel colliders
- Bump version to 0.4.13