### PR TITLE
Several Miscellaneous Fixes

### DIFF
--- a/CharApi/CharacterBuilding/FoyerCharacterHandler.cs
+++ b/CharApi/CharacterBuilding/FoyerCharacterHandler.cs
@@ -310,6 +310,15 @@ namespace Alexandria.CharacterAPI
         {
             try
             {
+                // Custom foyer controller setup
+                var customFoyerController = selectCharacter.gameObject.AddComponent<CustomCharacterFoyerController>();
+                customFoyerController.metaCost = data.metaCost;
+                customFoyerController.useGlow = data.useGlow;
+                customFoyerController.emissiveColor = data.emissiveColor;
+                customFoyerController.emissiveColorPower = data.emissiveColorPower;
+                customFoyerController.emissivePower = data.emissivePower;
+                customFoyerController.data = data;
+
                 if (selectCharacter.OverheadElement == null)
                 {
                     if (ToolsCharApi.EnableDebugLogging == true)
@@ -337,15 +346,6 @@ namespace Alexandria.CharacterAPI
                 newOverheadElement.SetActive(false);
                 newOverheadElement.name = $"CHR_{data.nameShort}Panel";
                 newOverheadElement.GetComponent<FoyerInfoPanelController>().followTransform = selectCharacter.transform; //NOTE: verify this is correct after instantiation
-
-                // Custom foyer controller setup
-                var customFoyerController = selectCharacter.gameObject.AddComponent<CustomCharacterFoyerController>();
-                customFoyerController.metaCost = data.metaCost;
-                customFoyerController.useGlow = data.useGlow;
-                customFoyerController.emissiveColor = data.emissiveColor;
-                customFoyerController.emissiveColorPower = data.emissiveColorPower;
-                customFoyerController.emissivePower = data.emissivePower;
-                customFoyerController.data = data;
 
                 //Change text
                 var infoPanel = newOverheadElement.GetComponent<FoyerInfoPanelController>();

--- a/CharApi/Tools/CharApiHooks.cs
+++ b/CharApi/Tools/CharApiHooks.cs
@@ -455,7 +455,7 @@ namespace Alexandria.CharacterAPI
             PlayerController player = GameManager.Instance.PrimaryPlayer;
             if (player && player.GetComponent<CustomCharacter>() is CustomCharacter cc && cc.data != null)
             {
-                __result = cc.name;
+                __result = cc.data.name;
                 return false;
             }
             return true;

--- a/EnemyAPI/BossBuilder.cs
+++ b/EnemyAPI/BossBuilder.cs
@@ -67,7 +67,8 @@ namespace Alexandria.EnemyAPI
 
             sprite.SetUpSpeculativeRigidbody(hitboxOffset, hitBoxSize).CollideWithOthers = true;
             prefab.AddComponent<tk2dSpriteAnimator>();
-            prefab.AddComponent<AIAnimator>();
+            AIAnimator aiAnimator = prefab.AddComponent<AIAnimator>();
+            aiAnimator.OtherVFX = new List<AIAnimator.NamedVFXPool>(0); // fixes a null deref on exit when destroying the fake prefab
 
             //setup knockback
             var knockback = prefab.AddComponent<KnockbackDoer>();

--- a/EnemyAPI/EnemyBuilder.cs
+++ b/EnemyAPI/EnemyBuilder.cs
@@ -90,7 +90,8 @@ namespace Alexandria.EnemyAPI
 
             sprite.SetUpSpeculativeRigidbody(hitboxOffset, hitBoxSize).CollideWithOthers = true;
             prefab.AddComponent<tk2dSpriteAnimator>();
-            prefab.AddComponent<AIAnimator>();
+            AIAnimator aiAnimator = prefab.AddComponent<AIAnimator>();
+            aiAnimator.OtherVFX = new List<AIAnimator.NamedVFXPool>(0); // fixes a null deref on exit when destroying the fake prefab
 
             //setup knockback
             var knockback = prefab.AddComponent<KnockbackDoer>();

--- a/ItemAPI/CompanionBuilder.cs
+++ b/ItemAPI/CompanionBuilder.cs
@@ -56,7 +56,8 @@ namespace Alexandria.ItemAPI
             tk2dSprite component = SpriteBuilder.SpriteFromResource(defaultSpritePath, gameObject, Assembly.GetCallingAssembly()).GetComponent<tk2dSprite>();
             component.SetUpSpeculativeRigidbody(hitboxOffset, hitBoxSize).CollideWithOthers = false;
             gameObject.AddComponent<tk2dSpriteAnimator>();
-            gameObject.AddComponent<AIAnimator>();
+            AIAnimator aiAnimator = gameObject.AddComponent<AIAnimator>();
+            aiAnimator.OtherVFX = new List<AIAnimator.NamedVFXPool>(0); // fixes a null deref on exit when destroying the fake prefab
             HealthHaver healthHaver = gameObject.AddComponent<HealthHaver>();
             healthHaver.RegisterBodySprite(component, false, 0);
             healthHaver.PreventAllDamage = true;

--- a/ItemAPI/SpriteTools/CustomClipAmmoTypeToolbox.cs
+++ b/ItemAPI/SpriteTools/CustomClipAmmoTypeToolbox.cs
@@ -27,7 +27,9 @@ namespace Alexandria.ItemAPI
             UnityEngine.Object.DontDestroyOnLoad(bgSpriteObject);
 
             dfTiledSprite fgSprite = fgSpriteObject.SetupDfSpriteFromTexture<dfTiledSprite>(fgTexture, ShaderCache.Acquire("Daikon Forge/Default UI Shader"));
+            fgSprite.zindex = 7;
             dfTiledSprite bgSprite = bgSpriteObject.SetupDfSpriteFromTexture<dfTiledSprite>(bgTexture, ShaderCache.Acquire("Daikon Forge/Default UI Shader"));
+            bgSprite.zindex = 5;
             GameUIAmmoType uiammotype = new GameUIAmmoType
             {
                 ammoBarBG = bgSprite,


### PR DESCRIPTION
- Fixed Z-ordering issue with custom ammo clip sprites
- Fixed null deref on game exit due to null `OtherVFX` on fake prefabs with an `AIAnimator`
- Fixed death screen showing `CustomCharacter` component name instead of character name
- Fixed issue in `CreateOverheadCard()` where `customFoyerController` was skipped when retrieving cached overhead cards